### PR TITLE
fix(auth): propagate the authenticated user to the request context

### DIFF
--- a/core/internal/auth/middleware.go
+++ b/core/internal/auth/middleware.go
@@ -14,7 +14,7 @@ const KeyUserCtx = "user"
 
 func Middleware(service *Service, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ok := CheckAuth(w, r, service)
+		r, ok := CheckAuth(w, r, service)
 		if !ok {
 			return
 		}
@@ -24,14 +24,20 @@ func Middleware(service *Service, next http.Handler) http.Handler {
 
 const oidcPage = "/api/auth/login/oidc"
 
-func CheckAuth(w http.ResponseWriter, r *http.Request, srv *Service) (ok bool) {
+// CheckAuth verifies the request's auth cookie. On success it returns a request
+// whose context carries the authenticated user (under KeyUserCtx) together with
+// ok=true; callers must forward the returned request downstream. On failure it
+// writes the appropriate response and returns ok=false.
+func CheckAuth(w http.ResponseWriter, r *http.Request, srv *Service) (*http.Request, bool) {
 	u, err := verifyCookie(r.Cookies(), srv)
 	if err == nil {
-		r.WithContext(context.WithValue(
+		// http.Request.WithContext returns a shallow copy; we must return it so
+		// the enriched context actually reaches the downstream handler.
+		r = r.WithContext(context.WithValue(
 			r.Context(),
 			KeyUserCtx, u,
 		))
-		return true
+		return r, true
 	}
 
 	if srv.config.OIDCEnable && srv.config.OIDCAutoRedirect {
@@ -42,11 +48,11 @@ func CheckAuth(w http.ResponseWriter, r *http.Request, srv *Service) (ok bool) {
 		if err != nil {
 			log.Warn().Err(err).Msg("Failed to write response")
 		}
-		return false
+		return r, false
 	}
 
 	http.Error(w, err.Error(), http.StatusUnauthorized)
-	return false
+	return r, false
 }
 
 func getCookie(cookieName string, cookies []*http.Cookie) (*http.Cookie, error) {

--- a/core/internal/auth/middleware_test.go
+++ b/core/internal/auth/middleware_test.go
@@ -1,0 +1,72 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeSessionStore is a minimal SessionStore that returns a fixed session,
+// letting us exercise the middleware without a database.
+type fakeSessionStore struct {
+	session Session
+	err     error
+}
+
+func (f *fakeSessionStore) NewSession(*Session) error                 { return nil }
+func (f *fakeSessionStore) DeleteSession(uint) error                  { return nil }
+func (f *fakeSessionStore) GetSession(uint) (Session, error)          { return f.session, f.err }
+func (f *fakeSessionStore) GetSessionByToken(string) (Session, error) { return f.session, f.err }
+
+// TestMiddleware_PropagatesUserToContext guards against a regression where
+// CheckAuth discarded the *http.Request returned by WithContext, so the
+// authenticated user never reached downstream handlers.
+func TestMiddleware_PropagatesUserToContext(t *testing.T) {
+	want := User{Username: "alice"}
+	srv := &Service{
+		config: &Config{},
+		sessionStore: &fakeSessionStore{
+			session: Session{
+				User:    want,
+				Expires: time.Now().Add(time.Hour),
+			},
+		},
+	}
+
+	var got *User
+	downstream := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		if u, ok := r.Context().Value(KeyUserCtx).(*User); ok {
+			got = u
+		}
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/protected/info", nil)
+	req.AddCookie(&http.Cookie{Name: CookieHeaderAuth, Value: "any-token"})
+	rec := httptest.NewRecorder()
+
+	Middleware(srv, downstream).ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, got, "authenticated user must reach the downstream handler via context")
+	require.Equal(t, want.Username, got.Username)
+}
+
+// TestMiddleware_RejectsMissingCookie ensures unauthenticated requests are
+// stopped with 401 and never reach the downstream handler.
+func TestMiddleware_RejectsMissingCookie(t *testing.T) {
+	srv := &Service{config: &Config{}, sessionStore: &fakeSessionStore{}}
+
+	called := false
+	downstream := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true })
+
+	req := httptest.NewRequest(http.MethodGet, "/api/protected/info", nil)
+	rec := httptest.NewRecorder()
+
+	Middleware(srv, downstream).ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	require.False(t, called, "downstream must not run for unauthenticated requests")
+}


### PR DESCRIPTION
## Problem

`CheckAuth` enriched the request with the authenticated user via
`r.WithContext(...)`, but the returned request was discarded. Downstream
handlers therefore never saw the user in their context.

## Fix

`CheckAuth` now returns the enriched `*http.Request`, and `Middleware`
forwards it down the chain so handlers can read the authenticated user.

## Testing

Adds `core/internal/auth/middleware_test.go` with a fake session store
covering the authenticated / unauthenticated paths.
