### PR TITLE
fix(host): identify the local host by type, not its mutable name

### DIFF
--- a/core/internal/host/service.go
+++ b/core/internal/host/service.go
@@ -55,7 +55,12 @@ const RootAlias = "compose"
 const LocalDocker = "local"
 
 func (s *Service) initLocalDocker(composeRoot string, localAddr string) {
-	conf, err := s.store.Get(LocalDocker)
+	// Look the local host up by its type, not by the reserved "local" name:
+	// the Name is user-editable, and keying on it meant that renaming the local
+	// host made this lookup fail on every startup, silently creating a duplicate
+	// local host (new ID) with only the default alias and orphaning the user's
+	// custom aliases (they are linked by host ID). Type is stable across renames.
+	conf, err := s.store.GetLocal()
 
 	// Case 1: Create new if it doesn't exist
 	if err != nil {

--- a/core/internal/host/store_host_config.go
+++ b/core/internal/host/store_host_config.go
@@ -7,6 +7,7 @@ import (
 
 type Store interface {
 	Get(Host string) (Config, error)
+	GetLocal() (Config, error)
 	Add(conf *Config) error
 	Delete(conf *Config) error
 	Update(conf *Config) error

--- a/core/internal/host/store_host_config_gorm.go
+++ b/core/internal/host/store_host_config_gorm.go
@@ -23,6 +23,21 @@ func (s *gormStore) Get(name string) (Config, error) {
 	return conf, err
 }
 
+// GetLocal retrieves the local host by its (immutable) Type rather than its
+// user-editable Name, so a renamed local host is still found instead of being
+// treated as missing. If several exist (e.g. duplicates from a previous bug),
+// the earliest-created one is returned so its aliases are preserved.
+func (s *gormStore) GetLocal() (Config, error) {
+	var conf Config
+	err := s.db.
+		Preload("SSHOptions").
+		Preload("FolderAliases").
+		Where("type = ?", LOCAL).
+		Order("created_at ASC").
+		First(&conf).Error
+	return conf, err
+}
+
 // Add inserts a new Config and its associations into the database
 func (s *gormStore) Add(conf *Config) error {
 	return s.db.Create(conf).Error


### PR DESCRIPTION
## Problem

The local Docker host was looked up by its **Name** (`"local"`). The Name is
user-editable, so renaming the local host made this lookup fail on every
startup — silently creating a **duplicate** local host (new ID) with only the
default alias, and orphaning the user's custom aliases (they are linked by
host ID). After a reboot the host would appear "lost" and had to be recreated
by hand.

## Fix

Identify the local host by its stable **Type** (`LOCAL`) instead of the mutable
Name. Adds a `GetLocal()` store method (WHERE type = LOCAL, oldest first) and
uses it from `initLocalDocker`.

## Testing

Verified on a homelab across container restarts / host reboots: the local
host and its custom aliases persist; no duplicate host is created after a
rename.
