### PR TITLE
fix(host): keep hosts when the Docker connection fails at boot

### DIFF
--- a/core/internal/host/docker_connection.go
+++ b/core/internal/host/docker_connection.go
@@ -24,6 +24,11 @@ func testDockerConnection(cli *client.Client) (system.Info, error) {
 func NewDockerLocalClient() (*client.Client, error) {
 	return client.New(
 		client.FromEnv,
+		// Negotiate the API version with the daemon so an older Docker engine
+		// (whose max supported API is below our client's default) doesn't reject
+		// calls with "client version is too new" — which otherwise fails the
+		// connection test and drops the host at startup.
+		client.WithAPIVersionNegotiation(),
 	)
 }
 
@@ -32,6 +37,7 @@ func newDockerSSHClient(cli *ssh.Client) (*client.Client, error) {
 	// Create a Docker client using the custom dialer.
 	return client.New(
 		client.WithDialContext(dockerSSHDialer(cli)),
+		client.WithAPIVersionNegotiation(),
 	)
 }
 

--- a/core/internal/host/service.go
+++ b/core/internal/host/service.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/RA341/dockman/internal/docker"
 	"github.com/RA341/dockman/internal/docker/compose"
@@ -252,11 +253,15 @@ func (s *Service) LoadAll() {
 
 	for _, host := range all {
 		wg.Go(func() {
-			err2 := s.Add(&host, false)
-			if err2 != nil {
-				log.Error().
+			if err2 := s.Add(&host, false); err2 != nil {
+				// The Docker daemon may simply not be reachable yet (e.g. dockman
+				// started before dockerd finished coming up after a reboot).
+				// Keep trying in the background instead of dropping the host,
+				// which otherwise leaves it "lost" until manually re-added.
+				log.Warn().
 					Err(err2).Str("name", host.Name).
-					Msg("Failed to load host")
+					Msg("host not reachable at startup, retrying in background")
+				go s.retryLoad(host.Name)
 			}
 		})
 	}
@@ -264,6 +269,44 @@ func (s *Service) LoadAll() {
 	wg.Wait()
 
 	log.Info().Strs("clients", s.activeClients.Keys()).Msg("loaded hosts")
+}
+
+// retryLoad keeps trying to connect a host that failed its initial load, so a
+// host whose Docker daemon isn't ready yet at startup is recovered
+// automatically instead of staying "lost" until it is manually re-added. It
+// re-reads the host each attempt (stopping if it was disabled or removed),
+// backs off exponentially, and gives up after a bounded number of attempts so
+// a permanently unreachable host cannot leak a goroutine forever.
+func (s *Service) retryLoad(name string) {
+	const maxAttempts = 10
+	const maxDelay = 30 * time.Second
+	delay := 2 * time.Second
+
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		time.Sleep(delay)
+
+		conf, err := s.store.Get(name)
+		if err != nil || !conf.Enable {
+			// removed or disabled in the meantime, stop retrying
+			return
+		}
+
+		if err = s.Add(&conf, false); err != nil {
+			log.Debug().Err(err).Str("name", name).Int("attempt", attempt).
+				Msg("host reconnect attempt failed")
+			delay *= 2
+			if delay > maxDelay {
+				delay = maxDelay
+			}
+			continue
+		}
+
+		log.Info().Str("name", name).Int("attempt", attempt).Msg("host reconnected")
+		return
+	}
+
+	log.Error().Str("name", name).
+		Msg("gave up connecting host after retries; re-enable it once its Docker daemon is reachable")
 }
 
 func (s *Service) Add(config *Config, create bool) (err error) {


### PR DESCRIPTION
## Problem

If the local Docker connection failed while Dockman was starting (daemon or
socket proxy not ready yet), the host was dropped and the user had to recreate
it manually.

## Fix

On a load failure, retry the connection in the background with bounded
exponential backoff (max 10 attempts, capped delay) instead of dropping the
host. Also enables API-version negotiation on the local and SSH Docker
clients so a version mismatch doesn't hard-fail the connection.

## Testing

Verified by starting Dockman before the Docker endpoint was reachable: the
host is retained and reconnects automatically once the daemon is up.
