### PR TITLE
feat(compose): show stack status on collapsed compose folders

### DIFF
--- a/core/internal/docker/compose/compose_terminal.go
+++ b/core/internal/docker/compose/compose_terminal.go
@@ -407,6 +407,19 @@ type StackState struct {
 	UnhealthyCount uint
 }
 
+// ComposeAbsPath returns the absolute path of the compose file as Docker Compose
+// records it in the com.docker.compose.project.config_files label. It reuses the
+// exact resolution the compose commands use (working dir = Fs.Root(), -f Relpath),
+// so running containers can be matched back to their compose file from a single
+// container listing — no per-stack `docker compose ps` process.
+func (c *Service) ComposeAbsPath(filename string) (string, error) {
+	parts, err := c.parser(filename, c.hostname)
+	if err != nil {
+		return "", err
+	}
+	return parts.Fs.Join(parts.Fs.Root(), parts.Relpath), nil
+}
+
 func (c *Service) Validate(ctx context.Context, filename string) []error {
 	buf := new(bytes.Buffer)
 	err := c.withCmd(ctx, filename, buf,

--- a/core/internal/docker/handler.go
+++ b/core/internal/docker/handler.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -17,9 +18,9 @@ import (
 	hm "github.com/RA341/dockman/internal/host/middleware"
 	"github.com/RA341/dockman/pkg/fileutil"
 	"github.com/RA341/dockman/pkg/listutils"
-	"github.com/RA341/dockman/pkg/syncmap"
 
 	"connectrpc.com/connect"
+	"github.com/docker/compose/v5/pkg/api"
 	"github.com/moby/moby/api/types/container"
 	"github.com/rs/zerolog/log"
 )
@@ -61,42 +62,117 @@ func (h *Handler) getHost(ctx context.Context) (string, *Service, error) {
 ////////////////////////////////////////////
 
 func (h *Handler) ComposeFileStatus(ctx context.Context, c *connect.Request[v1.ComposeFileStatusRequest]) (*connect.Response[v1.ComposeFileStatusResponse], error) {
-	var results = syncmap.Map[string, *v1.Status]{}
-
-	wg := sync.WaitGroup{}
-
-	for _, file := range c.Msg.Files {
-		wg.Go(func() {
-			err := h.WithClient(ctx, func(dkSrv *Service) error {
-				stat, err := dkSrv.Compose.Status(ctx, file)
-				if err != nil {
-					return err
-				}
-
-				results.Store(file, &v1.Status{
-					ServicesUp:        int32(stat.UpCount),
-					ServicesDown:      int32(stat.DownCount),
-					ServicesHealthy:   int32(stat.HealthyCount),
-					ServicesUnHealthy: int32(stat.UnhealthyCount),
-				})
-
-				return nil
-			})
-			if err != nil {
-				log.Warn().Str("file", file).Err(err).Msg("Failed to get compose status")
-			}
-		})
-	}
-	wg.Wait()
-
 	finalResults := make(map[string]*v1.Status, len(c.Msg.Files))
-	results.Range(func(key string, value *v1.Status) bool {
-		finalResults[key] = value
-		return true
+
+	err := h.WithClient(ctx, func(dkSrv *Service) error {
+		// One container listing for the whole host, aggregated per compose file
+		// via the compose config-files label. This replaces one `docker compose
+		// ps` subprocess per stack, so reporting the status of every stack (even
+		// collapsed ones) stays cheap no matter how many there are.
+		containers, err := dkSrv.Container.ContainersList(ctx)
+		if err != nil {
+			return err
+		}
+
+		byFile := make(map[string]*stackStatus)
+		for i := range containers {
+			ct := containers[i]
+			cfg := ct.Labels[api.ConfigFilesLabel]
+			if cfg == "" {
+				continue
+			}
+			// config_files may list several files (compose + overrides)
+			for _, p := range strings.Split(cfg, ",") {
+				if p = strings.TrimSpace(p); p == "" {
+					continue
+				}
+				st := byFile[p]
+				if st == nil {
+					st = &stackStatus{}
+					byFile[p] = st
+				}
+				st.add(ct)
+			}
+		}
+
+		for _, file := range c.Msg.Files {
+			absPath, resolveErr := dkSrv.Compose.ComposeAbsPath(file)
+			if resolveErr != nil {
+				log.Debug().Str("file", file).Err(resolveErr).Msg("could not resolve compose path for status")
+				finalResults[file] = &v1.Status{}
+				continue
+			}
+			if st, ok := byFile[absPath]; ok {
+				finalResults[file] = st.toProto()
+			} else {
+				// no containers for this stack -> stopped
+				finalResults[file] = &v1.Status{}
+			}
+		}
+		return nil
 	})
+	if err != nil {
+		return nil, err
+	}
+
 	return connect.NewResponse(&v1.ComposeFileStatusResponse{
 		Status: finalResults,
 	}), nil
+}
+
+// stackStatus aggregates the container states of a single compose stack.
+//
+// It maps onto the v1.Status fields the UI already consumes. ServicesDown carries
+// the "in error" count — a service that crashed, is dead, is stuck restarting, or
+// exited non-zero — so the UI can distinguish a real problem (red) from a stack
+// that is simply stopped (grey).
+type stackStatus struct {
+	up        int32
+	failed    int32
+	healthy   int32
+	unhealthy int32
+}
+
+func (s *stackStatus) add(ct container.Summary) {
+	switch string(ct.State) {
+	case "running":
+		s.up++
+		switch ct.Health.Status {
+		case container.Healthy:
+			s.healthy++
+		case container.Unhealthy:
+			s.unhealthy++
+		}
+	case "restarting", "dead":
+		s.failed++
+	case "exited":
+		if containerExitCode(ct) != 0 {
+			s.failed++
+		}
+		// exited(0) / created / paused / removing -> cleanly stopped, not counted
+	}
+}
+
+func (s *stackStatus) toProto() *v1.Status {
+	return &v1.Status{
+		ServicesUp:        s.up,
+		ServicesDown:      s.failed,
+		ServicesHealthy:   s.healthy,
+		ServicesUnHealthy: s.unhealthy,
+	}
+}
+
+// containerExitCode parses the exit code out of a container summary status line,
+// e.g. "Exited (137) 2 hours ago" -> 137. Returns 0 when it can't be determined.
+func containerExitCode(ct container.Summary) int {
+	l := strings.IndexByte(ct.Status, '(')
+	r := strings.IndexByte(ct.Status, ')')
+	if l >= 0 && r > l {
+		if code, err := strconv.Atoi(strings.TrimSpace(ct.Status[l+1 : r])); err == nil {
+			return code
+		}
+	}
+	return 0
 }
 
 func (h *Handler) ComposeUp(ctx context.Context, req *connect.Request[v1.ComposeFile], responseStream *connect.ServerStream[v1.LogsMessage]) error {

--- a/ui/src/pages/compose/components/file-item.tsx
+++ b/ui/src/pages/compose/components/file-item.tsx
@@ -514,9 +514,8 @@ const StatusIndicator = ({fileStatus}: { fileStatus: Status }) => {
                     width: 8,
                     height: 8,
                     borderRadius: '50%',
-                    bgcolor: stackStatus.label ? stackStatus.color : 'transparent',
-                    border: stackStatus.label ? 'none' : `2px solid ${stackStatus.color}`,
-                    boxShadow: `0 0 0 2px ${stackStatus.color}22`,
+                    flexShrink: 0,
+                    bgcolor: stackStatus.color,
                     ml: 1
                 }}
             />
@@ -527,15 +526,14 @@ const StatusIndicator = ({fileStatus}: { fileStatus: Status }) => {
 export default StatusIndicator;
 
 const getStatusTheme = (status: Status | undefined) => {
+    // Precedence: error > unhealthy > running > stopped. servicesDown carries the
+    // "in error" count (crashed / dead / restarting / exited non-zero).
     if (!status) {
-        return {color: 'text.disabled', label: ''};
+        return {color: 'grey.500', label: 'Stopped'};
     }
-
-    // servicesDown carries the "in error" count (crashed / dead / restarting /
-    // exited non-zero). Precedence: error > unhealthy > running > stopped.
     if (status.servicesDown > 0) return {color: 'error.main', label: 'Error'};
     if (status.servicesUnHealthy > 0) return {color: 'warning.main', label: 'Unhealthy'};
     if (status.servicesUp > 0) return {color: 'success.main', label: 'Running'};
-    // stopped -> hollow grey dot
-    return {color: 'text.disabled', label: ''};
+    // no running/failed/unhealthy container -> stack is stopped
+    return {color: 'grey.500', label: 'Stopped'};
 };

--- a/ui/src/pages/compose/components/file-item.tsx
+++ b/ui/src/pages/compose/components/file-item.tsx
@@ -146,8 +146,10 @@ const FolderItemDisplay = ({entry, depthIndex}: {
     }
 
     useEffect(() => {
-        if (!folderOpen && !isComposeFolder) {
-            closeComposeStatus(entry.filename)
+        if (!folderOpen) {
+            // Stop polling files nested inside the collapsed folder, but keep the
+            // folder's own stack status so its dot stays visible while collapsed.
+            closeComposeStatus(entry.filename, entry.isComposeFolder)
         }
     }, [folderOpen]);
 
@@ -174,10 +176,13 @@ const FolderItemDisplay = ({entry, depthIndex}: {
 
     const fileStatus = useComposeFileState(state => state.openFiles[getContextKey()]?.[entry.isComposeFolder])
     useEffect(() => {
-        if (isComposeFolder) {
+        // Track the stack status for any folder that contains a compose file,
+        // regardless of the useComposeFolders display mode, so the status dot is
+        // shown even while the folder is collapsed.
+        if (entry.isComposeFolder) {
             trackComposeStatus(entry.isComposeFolder);
         }
-    }, [isComposeFolder, entry.isComposeFolder]);
+    }, [entry.isComposeFolder]);
 
     const navigate = useNavigate()
     const createFileUrl = useEditorUrl()
@@ -502,7 +507,7 @@ const StatusIndicator = ({fileStatus}: { fileStatus: Status }) => {
 
     return ((fileStatus) &&
         <Tooltip
-            title={`${fileStatus.servicesUp} Up, ${fileStatus.servicesDown} Down, ${fileStatus.servicesHealthy} Healthy`}
+            title={`${fileStatus.servicesUp} running · ${fileStatus.servicesDown} failed · ${fileStatus.servicesHealthy} healthy`}
             arrow placement="right">
             <Box
                 sx={{
@@ -526,10 +531,11 @@ const getStatusTheme = (status: Status | undefined) => {
         return {color: 'text.disabled', label: ''};
     }
 
-    if (status.servicesUnHealthy > 0) return {color: 'error.main', label: 'Unhealthy'};
-    if (status.servicesDown > 0 && status.servicesUp > 0) return {color: 'warning.main', label: 'Partially Up'};
-    if (status.servicesDown > 0 && status.servicesUp === 0) return {color: 'error.light', label: 'Down'};
-    if (status.servicesHealthy > 0) return {color: 'success.main', label: 'Healthy'};
-    if (status.servicesUp > 0) return {color: 'success.light', label: 'Running'};
+    // servicesDown carries the "in error" count (crashed / dead / restarting /
+    // exited non-zero). Precedence: error > unhealthy > running > stopped.
+    if (status.servicesDown > 0) return {color: 'error.main', label: 'Error'};
+    if (status.servicesUnHealthy > 0) return {color: 'warning.main', label: 'Unhealthy'};
+    if (status.servicesUp > 0) return {color: 'success.main', label: 'Running'};
+    // stopped -> hollow grey dot
     return {color: 'text.disabled', label: ''};
 };

--- a/ui/src/pages/compose/components/file-item.tsx
+++ b/ui/src/pages/compose/components/file-item.tsx
@@ -515,7 +515,13 @@ const StatusIndicator = ({fileStatus}: { fileStatus: Status }) => {
                     height: 8,
                     borderRadius: '50%',
                     flexShrink: 0,
-                    bgcolor: stackStatus.color,
+                    boxSizing: 'border-box',
+                    // filled dot for active states, hollow ring for a stopped
+                    // stack so it reads clearly differently from a green dot.
+                    // borderColor (not the `border` shorthand) resolves the token.
+                    ...(stackStatus.filled
+                        ? {bgcolor: stackStatus.color}
+                        : {border: '2px solid', borderColor: stackStatus.color}),
                     ml: 1
                 }}
             />
@@ -529,11 +535,11 @@ const getStatusTheme = (status: Status | undefined) => {
     // Precedence: error > unhealthy > running > stopped. servicesDown carries the
     // "in error" count (crashed / dead / restarting / exited non-zero).
     if (!status) {
-        return {color: 'grey.500', label: 'Stopped'};
+        return {color: 'grey.500', label: 'Stopped', filled: false};
     }
-    if (status.servicesDown > 0) return {color: 'error.main', label: 'Error'};
-    if (status.servicesUnHealthy > 0) return {color: 'warning.main', label: 'Unhealthy'};
-    if (status.servicesUp > 0) return {color: 'success.main', label: 'Running'};
+    if (status.servicesDown > 0) return {color: 'error.main', label: 'Error', filled: true};
+    if (status.servicesUnHealthy > 0) return {color: 'warning.main', label: 'Unhealthy', filled: true};
+    if (status.servicesUp > 0) return {color: 'success.main', label: 'Running', filled: true};
     // no running/failed/unhealthy container -> stack is stopped
-    return {color: 'grey.500', label: 'Stopped'};
+    return {color: 'grey.500', label: 'Stopped', filled: false};
 };

--- a/ui/src/pages/compose/state/status.ts
+++ b/ui/src/pages/compose/state/status.ts
@@ -42,7 +42,13 @@ export const useComposeFileState = create<OpenFilesState>()(
                     state.openFiles[key] = <Record<string, Status>>{};
                 }
 
-                state.openFiles[key][path] = createMessage(StatusSchema);
+                // Only initialise when not already tracked. Re-tracking a path
+                // (e.g. when a folder is expanded and its compose child mounts)
+                // must not reset an already-known status to empty, otherwise the
+                // dot flickers to grey until the next poll.
+                if (!state.openFiles[key][path]) {
+                    state.openFiles[key][path] = createMessage(StatusSchema);
+                }
             });
         },
 

--- a/ui/src/pages/compose/state/status.ts
+++ b/ui/src/pages/compose/state/status.ts
@@ -7,7 +7,7 @@ import {create} from "zustand";
 interface OpenFilesState {
     // contextKey -> Set of directory paths
     openFiles: Record<string, Record<string, Status>>;
-    delete: (dir: string) => void;
+    delete: (dir: string, keep?: string) => void;
     trackComposeStatus: (path: string) => void;
     setStatus: (status: { [p: string]: Status }) => void
 }
@@ -16,7 +16,7 @@ export const useComposeFileState = create<OpenFilesState>()(
     immer((set) => ({
         openFiles: {},
 
-        delete: (dir: string) => {
+        delete: (dir: string, keep?: string) => {
             const key = getContextKey();
             set((state) => {
                 const openStatuses = state.openFiles[key];
@@ -25,8 +25,10 @@ export const useComposeFileState = create<OpenFilesState>()(
                 }
 
                 for (const trackingFile of Object.keys(openStatuses)) {
-                    if (trackingFile.startsWith(dir)) {
-                        console.log(`Removing ${trackingFile} because ${dir} was closed`)
+                    // keep lets a collapsed stack folder retain its own compose
+                    // status (so its dot stays visible) while dropping the files
+                    // nested inside it.
+                    if (trackingFile !== keep && trackingFile.startsWith(dir)) {
                         delete state.openFiles[key][trackingFile];
                     }
                 }


### PR DESCRIPTION
Closes #162

## Problem

Stack status dots only showed when a compose folder was **expanded**. When the
folder was collapsed there was no indication of whether the stack was running.

## Fix

Compute per-stack status from a **single** `ContainersList` API call,
aggregated by the compose config-files label, instead of spawning N
`docker compose ps` subprocesses. This keeps it cheap — no extra RAM/CPU and
nothing running in a loop.

Status is derived per stack and mapped to a colour:

- **green** — all services up & healthy (or no healthcheck)
- **orange** — at least one service unhealthy
- **red** — at least one service failed (non-zero exit)
- **grey ring** — stack fully stopped

The status is kept in sync when a stack starts/stops, and a hollow grey ring
is used for the stopped state (per an existing request).

## Testing

Verified on a homelab: collapsed folders show the correct colour, transitions
(running → stopped → failed) update live.
