### PR TITLE
feat(update): manual Dockman self-update via a throwaway helper

### DIFF
--- a/core/internal/app/app.go
+++ b/core/internal/app/app.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -108,6 +109,12 @@ func NewApp(opt ...config.AppOpt) (app *App) {
 		conf.ComposeRoot,
 		conf.LocalAddr,
 	)
+
+	// best-effort: remove a leftover self-update helper container from a
+	// previous update once the local docker host is reachable.
+	if dkSrv, err := hostManager.GetDockerService(host.LocalDocker); err == nil {
+		docker.CleanupSelfUpdateHelper(context.Background(), dkSrv.Container.Cli())
+	}
 
 	fileSrv := files.New(
 		hostManager.GetAlias,

--- a/core/internal/docker/handler_http.go
+++ b/core/internal/docker/handler_http.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 
+	contSrv "github.com/RA341/dockman/internal/docker/container"
 	"github.com/RA341/dockman/internal/docker/debug"
 	hostMid "github.com/RA341/dockman/internal/host/middleware"
 	fu "github.com/RA341/dockman/pkg/fileutil"
@@ -34,8 +35,41 @@ func (h *HandlerHttp) register() http.Handler {
 	subMux := http.NewServeMux()
 	subMux.HandleFunc("GET /exec/{contId}", h.containerExec)
 	subMux.HandleFunc("GET /logs/{contId}", h.containerLogs)
+	subMux.HandleFunc("POST /update/dockman", h.updateDockman)
 
 	return subMux
+}
+
+// updateDockman triggers a manual self-update of the Dockman container on the
+// local host. It launches a detached helper that recreates Dockman with the
+// latest image; see SelfUpdate.
+func (h *HandlerHttp) updateDockman(w http.ResponseWriter, r *http.Request) {
+	host, err := hostMid.GetHost(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if host != contSrv.LocalClient {
+		http.Error(w, "self-update is only supported on the local host", http.StatusBadRequest)
+		return
+	}
+
+	dkSrv, err := h.srv(host)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("error getting docker service: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	// Detached context: the update must finish even if the client disconnects
+	// (Dockman is about to restart anyway).
+	if err = SelfUpdate(context.Background(), dkSrv); err != nil {
+		log.Error().Err(err).Msg("dockman self-update failed")
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusAccepted)
+	_, _ = w.Write([]byte("Dockman update started; it will restart shortly."))
 }
 
 func (h *HandlerHttp) containerExec(w http.ResponseWriter, r *http.Request) {

--- a/core/internal/docker/selfupdate.go
+++ b/core/internal/docker/selfupdate.go
@@ -1,0 +1,149 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/docker/compose/v5/pkg/api"
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/mount"
+	"github.com/moby/moby/client"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	// selfUpdateContainerName is the fixed name of the throwaway helper so it can
+	// be found and cleaned up on the next Dockman startup.
+	selfUpdateContainerName = "dockman-self-update"
+	// selfUpdateHelperImage carries a docker CLI + compose plugin.
+	selfUpdateHelperImage = "docker:cli"
+	// dockmanContainerLabel is set on the Dockman image (see pkg/docker/Dockerfile).
+	dockmanContainerLabel = "dockman.container"
+)
+
+// SelfUpdate pulls the latest Dockman image and recreates the Dockman container.
+//
+// A container cannot recreate itself while running (stopping itself kills the
+// process doing the work), so Dockman launches a short-lived, DETACHED helper
+// container that runs `docker compose up -d` for the Dockman service and then
+// exits. The helper outlives Dockman during the swap. It is left in place after
+// it finishes (so its logs stay inspectable) and is removed on the next
+// successful Dockman startup by CleanupSelfUpdateHelper.
+func SelfUpdate(ctx context.Context, dkSrv *Service) error {
+	cli := dkSrv.Container.Cli()
+
+	self, err := findSelfContainer(ctx, cli)
+	if err != nil {
+		return err
+	}
+
+	composeFile := self.Labels[api.ConfigFilesLabel]
+	service := self.Labels[api.ServiceLabel]
+	project := self.Labels[api.ProjectLabel]
+	if composeFile == "" || service == "" {
+		return fmt.Errorf("the Dockman container is not managed by docker compose " +
+			"(no compose labels found), self-update is unavailable")
+	}
+
+	// Remove a leftover helper from a previous run, if any.
+	cleanupSelfUpdateHelper(ctx, cli)
+
+	if err = pullImage(ctx, cli, selfUpdateHelperImage); err != nil {
+		return fmt.Errorf("failed to pull helper image %s: %w", selfUpdateHelperImage, err)
+	}
+
+	// Mount the compose file's parent directory so relative env_file paths such
+	// as `../.env` resolve inside the helper. Guard against mounting the host root.
+	mountDir := filepath.Dir(filepath.Dir(composeFile))
+	if mountDir == "/" || mountDir == "." || mountDir == "" {
+		mountDir = filepath.Dir(composeFile)
+	}
+
+	// sleep briefly so the HTTP response reaches the UI before Dockman is recreated.
+	script := fmt.Sprintf(
+		"set -e; sleep 3; echo 'Updating Dockman...'; docker compose -f %q -p %q up -d --pull always %q",
+		composeFile, project, service,
+	)
+
+	created, err := cli.ContainerCreate(ctx, client.ContainerCreateOptions{
+		Name: selfUpdateContainerName,
+		Config: &container.Config{
+			Image:      selfUpdateHelperImage,
+			Entrypoint: []string{"sh"},
+			Cmd:        []string{"-c", script},
+			// Never let Dockman mistake the helper for itself.
+			Labels: map[string]string{dockmanContainerLabel: "false"},
+		},
+		HostConfig: &container.HostConfig{
+			Mounts: []mount.Mount{
+				{Type: mount.TypeBind, Source: "/var/run/docker.sock", Target: "/var/run/docker.sock"},
+				{Type: mount.TypeBind, Source: mountDir, Target: mountDir},
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create self-update helper: %w", err)
+	}
+
+	if _, err = cli.ContainerStart(ctx, created.ID, client.ContainerStartOptions{}); err != nil {
+		return fmt.Errorf("failed to start self-update helper: %w", err)
+	}
+
+	log.Info().Str("service", service).Str("composeFile", composeFile).
+		Msg("Dockman self-update helper launched; Dockman will restart shortly")
+	return nil
+}
+
+// CleanupSelfUpdateHelper removes a leftover self-update helper container if one
+// is still around. Safe to call on every startup; a no-op when nothing exists.
+func CleanupSelfUpdateHelper(ctx context.Context, cli *client.Client) {
+	cleanupSelfUpdateHelper(ctx, cli)
+}
+
+func cleanupSelfUpdateHelper(ctx context.Context, cli *client.Client) {
+	if _, err := cli.ContainerRemove(ctx, selfUpdateContainerName, client.ContainerRemoveOptions{
+		Force: true,
+	}); err != nil {
+		log.Debug().Err(err).Msg("no self-update helper container to clean up")
+	}
+}
+
+// findSelfContainer locates the running Dockman container via its image label,
+// preferring the one whose id matches this process's hostname.
+func findSelfContainer(ctx context.Context, cli *client.Client) (container.Summary, error) {
+	list, err := cli.ContainerList(ctx, client.ContainerListOptions{All: true})
+	if err != nil {
+		return container.Summary{}, err
+	}
+
+	hostname, _ := os.Hostname()
+	var fallback *container.Summary
+	for i := range list.Items {
+		c := list.Items[i]
+		if c.Labels[dockmanContainerLabel] != "true" {
+			continue
+		}
+		if hostname != "" && strings.HasPrefix(c.ID, hostname) {
+			return c, nil
+		}
+		if fallback == nil {
+			cpy := c
+			fallback = &cpy
+		}
+	}
+	if fallback != nil {
+		return *fallback, nil
+	}
+	return container.Summary{}, fmt.Errorf("could not find the Dockman container (label %s=true)", dockmanContainerLabel)
+}
+
+func pullImage(ctx context.Context, cli *client.Client, image string) error {
+	progress, err := cli.ImagePull(ctx, image, client.ImagePullOptions{})
+	if err != nil {
+		return err
+	}
+	return progress.Wait(ctx)
+}

--- a/core/internal/docker/selfupdate.go
+++ b/core/internal/docker/selfupdate.go
@@ -29,9 +29,13 @@ const (
 // A container cannot recreate itself while running (stopping itself kills the
 // process doing the work), so Dockman launches a short-lived, DETACHED helper
 // container that runs `docker compose up -d` for the Dockman service and then
-// exits. The helper outlives Dockman during the swap. It is left in place after
-// it finishes (so its logs stay inspectable) and is removed on the next
-// successful Dockman startup by CleanupSelfUpdateHelper.
+// exits. The helper outlives Dockman during the swap.
+//
+// On a SUCCESSFUL update the helper removes itself (via the raw socket, so it
+// never depends on Dockman's socket proxy allowing a DELETE). On FAILURE it is
+// left in place so `docker logs dockman-self-update` stays inspectable; that
+// leftover is swept on the next successful Dockman startup by
+// CleanupSelfUpdateHelper.
 func SelfUpdate(ctx context.Context, dkSrv *Service) error {
 	cli := dkSrv.Container.Cli()
 
@@ -70,6 +74,10 @@ func SelfUpdate(ctx context.Context, dkSrv *Service) error {
 	// container on the pulled image. A parent-level `../.env` is passed
 	// explicitly since compose only auto-loads a .env from the project directory.
 	// Identity is passed in via env, resolved by Dockman from its own container.
+	//
+	// On success the helper removes itself over the same raw socket. `set -e`
+	// means a failed compose run skips the self-removal, leaving the helper (and
+	// its logs) in place for troubleshooting.
 	const script = `set -e
 sleep 3
 cd "$DK_COMPOSE_DIR"
@@ -78,7 +86,9 @@ ENVFLAG=""
 PROJ=""
 [ -n "$DK_PROJECT" ] && PROJ="-p $DK_PROJECT"
 echo "Updating Dockman ($DK_SERVICE)..."
-docker compose $ENVFLAG $PROJ -f "$DK_COMPOSE_FILE" up -d --pull always --build --no-deps --force-recreate "$DK_SERVICE"`
+docker compose $ENVFLAG $PROJ -f "$DK_COMPOSE_FILE" up -d --pull always --build --no-deps --force-recreate "$DK_SERVICE"
+echo "Update complete; removing helper."
+docker rm -f "$DK_SELF" || true`
 
 	created, err := cli.ContainerCreate(ctx, client.ContainerCreateOptions{
 		Name: selfUpdateContainerName,
@@ -91,6 +101,7 @@ docker compose $ENVFLAG $PROJ -f "$DK_COMPOSE_FILE" up -d --pull always --build 
 				"DK_COMPOSE_DIR=" + composeDir,
 				"DK_PROJECT=" + project,
 				"DK_SERVICE=" + service,
+				"DK_SELF=" + selfUpdateContainerName,
 			},
 			// Never let Dockman mistake the helper for itself.
 			Labels: map[string]string{dockmanContainerLabel: "false"},

--- a/core/internal/docker/selfupdate.go
+++ b/core/internal/docker/selfupdate.go
@@ -55,18 +55,30 @@ func SelfUpdate(ctx context.Context, dkSrv *Service) error {
 		return fmt.Errorf("failed to pull helper image %s: %w", selfUpdateHelperImage, err)
 	}
 
-	// Mount the compose file's parent directory so relative env_file paths such
-	// as `../.env` resolve inside the helper. Guard against mounting the host root.
-	mountDir := filepath.Dir(filepath.Dir(composeFile))
+	composeDir := filepath.Dir(composeFile)
+	// Mount the compose dir's parent so both the compose file and a parent-level
+	// env file (e.g. `env_file: ../.env`) are visible to the helper. Guard against
+	// mounting the host root.
+	mountDir := filepath.Dir(composeDir)
 	if mountDir == "/" || mountDir == "." || mountDir == "" {
-		mountDir = filepath.Dir(composeFile)
+		mountDir = composeDir
 	}
 
-	// sleep briefly so the HTTP response reaches the UI before Dockman is recreated.
-	script := fmt.Sprintf(
-		"set -e; sleep 3; echo 'Updating Dockman...'; docker compose -f %q -p %q up -d --pull always %q",
-		composeFile, project, service,
-	)
+	// The helper talks to the daemon over the raw docker socket (not Dockman's
+	// proxy) and recreates ONLY the Dockman service: --no-deps so sidecars such
+	// as a socket proxy are never touched, --force-recreate to guarantee a fresh
+	// container on the pulled image. A parent-level `../.env` is passed
+	// explicitly since compose only auto-loads a .env from the project directory.
+	// Identity is passed in via env, resolved by Dockman from its own container.
+	const script = `set -e
+sleep 3
+cd "$DK_COMPOSE_DIR"
+ENVFLAG=""
+[ -f ../.env ] && ENVFLAG="--env-file ../.env"
+PROJ=""
+[ -n "$DK_PROJECT" ] && PROJ="-p $DK_PROJECT"
+echo "Updating Dockman ($DK_SERVICE)..."
+docker compose $ENVFLAG $PROJ -f "$DK_COMPOSE_FILE" up -d --pull always --build --no-deps --force-recreate "$DK_SERVICE"`
 
 	created, err := cli.ContainerCreate(ctx, client.ContainerCreateOptions{
 		Name: selfUpdateContainerName,
@@ -74,6 +86,12 @@ func SelfUpdate(ctx context.Context, dkSrv *Service) error {
 			Image:      selfUpdateHelperImage,
 			Entrypoint: []string{"sh"},
 			Cmd:        []string{"-c", script},
+			Env: []string{
+				"DK_COMPOSE_FILE=" + composeFile,
+				"DK_COMPOSE_DIR=" + composeDir,
+				"DK_PROJECT=" + project,
+				"DK_SERVICE=" + service,
+			},
 			// Never let Dockman mistake the helper for itself.
 			Labels: map[string]string{dockmanContainerLabel: "false"},
 		},

--- a/ui/src/pages/settings/settings-page.tsx
+++ b/ui/src/pages/settings/settings-page.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {Box, Tab, Tabs} from "@mui/material";
 import {useSearchParams} from 'react-router-dom';
 import TabDockerHosts from "./tab-host.tsx";
+import TabDockman from "./tab-dockman.tsx";
 
 interface TabConfig {
     label: string;
@@ -12,6 +13,10 @@ const tabConfigurations: TabConfig[] = [
     {
         label: "Docker Hosts",
         component: <TabDockerHosts/>
+    },
+    {
+        label: "Dockman",
+        component: <TabDockman/>
     },
 ];
 

--- a/ui/src/pages/settings/tab-dockman.tsx
+++ b/ui/src/pages/settings/tab-dockman.tsx
@@ -1,0 +1,61 @@
+import {Box, Button, CircularProgress, Typography} from "@mui/material";
+import {useState} from "react";
+import {getBaseUrl} from "../../lib/api.ts";
+import {useSnackbar} from "../../hooks/snackbar.ts";
+
+export default function TabDockman() {
+    const {showError, showSuccess} = useSnackbar();
+    const [updating, setUpdating] = useState(false);
+
+    const handleUpdate = async () => {
+        const ok = window.confirm(
+            "Pull the latest Dockman image and recreate the container?\n\n" +
+            "Dockman will briefly go offline while it restarts."
+        );
+        if (!ok) return;
+
+        setUpdating(true);
+        try {
+            const res = await fetch(`${getBaseUrl("host", "local")}/docker/update/dockman`, {
+                method: "POST",
+            });
+            if (!res.ok) {
+                showError(`Update failed: ${res.status} ${await res.text()}`);
+                return;
+            }
+            showSuccess("Update started — Dockman will restart shortly.");
+        } catch (e) {
+            showError(`Update failed: ${(e as Error).message}`);
+        } finally {
+            setUpdating(false);
+        }
+    };
+
+    return (
+        <Box sx={{display: "flex", justifyContent: "center", p: 4}}>
+            <Box sx={{
+                width: "100%",
+                maxWidth: 640,
+                border: "1px solid",
+                borderColor: "divider",
+                borderRadius: 2,
+                p: 3,
+            }}>
+                <Typography variant="h6" gutterBottom>Update Dockman</Typography>
+                <Typography variant="body2" color="text.secondary" sx={{mb: 2}}>
+                    Pulls the latest Dockman image and recreates the container through a
+                    short-lived helper. Dockman restarts and is briefly unavailable; your
+                    compose configuration is reused as-is.
+                </Typography>
+                <Button
+                    variant="contained"
+                    onClick={handleUpdate}
+                    disabled={updating}
+                    startIcon={updating ? <CircularProgress size={16} color="inherit"/> : undefined}
+                >
+                    {updating ? "Starting update…" : "Update Dockman"}
+                </Button>
+            </Box>
+        </Box>
+    );
+}


### PR DESCRIPTION
## What

Adds a manual **"Update Dockman"** action (Settings → Dockman) that pulls the
latest image and recreates the Dockman container.

## Why it needs a helper

A container can't recreate itself while running — stopping itself kills the
process doing the work. So Dockman launches a short-lived, detached helper
container (`docker:cli`) that performs the swap and then exits.

## Design

The helper recreates **only** the Dockman service, over the **raw** docker
socket (not Dockman's socket proxy):

```
docker compose --env-file ../.env -f <compose> -p <project> \
  up -d --pull always --build --no-deps --force-recreate <dockman-service>
```

- `--no-deps` guarantees sidecars (e.g. a socket proxy) are never touched.
- `--force-recreate` guarantees a fresh container on the pulled image.
- Identity (compose file / project / service) is resolved from Dockman's own
  container labels and passed to the helper via env — nothing hardcoded.
- The helper **self-removes on success** over the raw socket; on failure it is
  left in place so `docker logs dockman-self-update` stays inspectable, and it
  is swept on the next successful startup.

Manual-only; nothing automatic. Scoped to the local host.

## Testing

Verified on a homelab that uses a Docker socket proxy: Dockman updates and
restarts, dependencies (incl. the proxy) are untouched, and the helper is
cleaned up after a successful update.

## Note

The helper relies on `docker:cli` shipping the compose plugin. Happy to switch
the helper image if you'd prefer a different guarantee.
