### PR TITLE
fix(cleaner): upsert prune config so enabling the cleaner works

### DIFF
--- a/core/internal/cleaner/handler.go
+++ b/core/internal/cleaner/handler.go
@@ -180,6 +180,10 @@ func (h *Handler) EditConfig(ctx context.Context, req *connect.Request[v1.EditCo
 	cf.FromProto(req.Msg.Config)
 	cf.Host = hostname
 
+	if cf.Enabled && cf.Interval <= 0 {
+		return nil, fmt.Errorf("set a maintenance interval greater than 0 to enable auto-pruning")
+	}
+
 	err = h.srv.store.UpdateConfig(&cf)
 	if err != nil {
 		return nil, fmt.Errorf("unable to update config: %v", err)
@@ -190,9 +194,14 @@ func (h *Handler) EditConfig(ctx context.Context, req *connect.Request[v1.EditCo
 		return nil, err
 	}
 
-	err = h.srv.RunWithScheduler(hostname, true)
-	if err != nil {
-		return nil, err
+	// Only (re)schedule when enabled; saving a disabled config must tear down any
+	// running job instead of erroring out.
+	if getConfig.Enabled {
+		if err = h.srv.RunWithScheduler(hostname, true); err != nil {
+			return nil, err
+		}
+	} else {
+		h.srv.StopScheduler(hostname)
 	}
 
 	return connect.NewResponse(&v1.EditConfigResponse{

--- a/core/internal/cleaner/service.go
+++ b/core/internal/cleaner/service.go
@@ -126,7 +126,10 @@ func (s *Service) RunWithScheduler(host string, edit bool) error {
 		return err
 	}
 	if !getConfig.Enabled {
-		return fmt.Errorf("enabled cleaner run")
+		return fmt.Errorf("cleaner is disabled for host %q; enable it first", host)
+	}
+	if getConfig.Interval <= 0 {
+		return fmt.Errorf("cleaner interval must be greater than 0 for host %q", host)
 	}
 
 	var jb gocron.Job
@@ -149,6 +152,19 @@ func (s *Service) RunWithScheduler(host string, edit bool) error {
 
 	s.taskList.Store(host, jb)
 	return jb.RunNow()
+}
+
+// StopScheduler removes any scheduled cleaner job for the host. It is a no-op
+// when nothing is scheduled, so it is safe to call whenever a config is saved
+// with the cleaner disabled.
+func (s *Service) StopScheduler(host string) {
+	jb, ok := s.taskList.LoadAndDelete(host)
+	if !ok {
+		return
+	}
+	if err := s.schd.RemoveJob(jb.ID()); err != nil {
+		s.log.Warn().Err(err).Str("host", host).Msg("failed to remove cleaner job")
+	}
 }
 
 func (s *Service) clean(ctx context.Context, host string) {

--- a/core/internal/cleaner/store_gorm.go
+++ b/core/internal/cleaner/store_gorm.go
@@ -2,6 +2,7 @@ package cleaner
 
 import (
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type GormStore struct {
@@ -24,7 +25,19 @@ func (g *GormStore) GetConfig(host string) (PruneConfig, error) {
 }
 
 func (g *GormStore) UpdateConfig(config *PruneConfig) error {
-	return g.db.Updates(config).Error
+	// Upsert keyed on the unique host column. Updates() alone fails with
+	// "WHERE conditions required" because the incoming config carries no primary
+	// key, and on the first save no row exists for the host yet. ON CONFLICT(host)
+	// DO UPDATE inserts the first time and updates thereafter, and (via
+	// AssignmentColumns) correctly persists toggles set back to false.
+	return g.db.Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "host"}},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"enabled", "interval",
+			"volumes", "networks", "images", "containers", "build_cache",
+			"updated_at",
+		}),
+	}).Create(config).Error
 }
 
 const maxPruneResults = 10


### PR DESCRIPTION
## Problem

Enabling the Docker cleaner failed with a 500:

```
unable to update config: WHERE conditions required
```

`UpdateConfig` called gorm `Updates()` on a `PruneConfig` with no primary key,
and on the first save no row exists for the host — so GORM refused the global
UPDATE. Because the config was never persisted, `Enabled` stayed `false` and
**Run Now** then failed too with `enabled cleaner run`.

## Fix

- `UpdateConfig` now **upserts** via `ON CONFLICT(host) DO UPDATE` (the `host`
  column already has a unique index), inserting the first time and updating
  thereafter, including toggles reset to `false`.
- `EditConfig` only (re)schedules when the saved config is enabled and tears
  the job down otherwise, so saving a **disabled** config no longer 500s; it
  also rejects enabling with a zero interval up front.
- Clearer scheduler errors (disabled host / non-positive interval) replace the
  cryptic `enabled cleaner run`.

## Testing

Verified on a homelab: enabling the cleaner with an interval saves and runs;
toggling options and disabling all persist correctly; "Run Now" works.
