### PR TITLE
feat(stats): honor a stats.sort config from dockman.yml

### DIFF
--- a/core/generated/dockyaml/v1/dockyaml.pb.go
+++ b/core/generated/dockyaml/v1/dockyaml.pb.go
@@ -272,6 +272,7 @@ type DockmanYaml struct {
 	NetworkPage                *NetworkConfig         `protobuf:"bytes,3,opt,name=networkPage,proto3" json:"networkPage,omitempty"`
 	ImagePage                  *ImageConfig           `protobuf:"bytes,4,opt,name=imagePage,proto3" json:"imagePage,omitempty"`
 	ContainerPage              *ContainerConfig       `protobuf:"bytes,5,opt,name=containerPage,proto3" json:"containerPage,omitempty"`
+	StatsPage                  *StatsConfig           `protobuf:"bytes,10,opt,name=statsPage,proto3" json:"statsPage,omitempty"`
 	unknownFields              protoimpl.UnknownFields
 	sizeCache                  protoimpl.SizeCache
 }
@@ -365,6 +366,13 @@ func (x *DockmanYaml) GetImagePage() *ImageConfig {
 func (x *DockmanYaml) GetContainerPage() *ContainerConfig {
 	if x != nil {
 		return x.ContainerPage
+	}
+	return nil
+}
+
+func (x *DockmanYaml) GetStatsPage() *StatsConfig {
+	if x != nil {
+		return x.StatsPage
 	}
 	return nil
 }
@@ -545,6 +553,50 @@ func (x *ContainerConfig) GetSort() *Sort {
 	return nil
 }
 
+type StatsConfig struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Sort          *Sort                  `protobuf:"bytes,1,opt,name=sort,proto3" json:"sort,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StatsConfig) Reset() {
+	*x = StatsConfig{}
+	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StatsConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StatsConfig) ProtoMessage() {}
+
+func (x *StatsConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StatsConfig.ProtoReflect.Descriptor instead.
+func (*StatsConfig) Descriptor() ([]byte, []int) {
+	return file_dockyaml_v1_dockyaml_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *StatsConfig) GetSort() *Sort {
+	if x != nil {
+		return x.Sort
+	}
+	return nil
+}
+
 type Sort struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	SortOrder     string                 `protobuf:"bytes,1,opt,name=sortOrder,proto3" json:"sortOrder,omitempty"`
@@ -555,7 +607,7 @@ type Sort struct {
 
 func (x *Sort) Reset() {
 	*x = Sort{}
-	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[11]
+	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -567,7 +619,7 @@ func (x *Sort) String() string {
 func (*Sort) ProtoMessage() {}
 
 func (x *Sort) ProtoReflect() protoreflect.Message {
-	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[11]
+	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -580,7 +632,7 @@ func (x *Sort) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Sort.ProtoReflect.Descriptor instead.
 func (*Sort) Descriptor() ([]byte, []int) {
-	return file_dockyaml_v1_dockyaml_proto_rawDescGZIP(), []int{11}
+	return file_dockyaml_v1_dockyaml_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *Sort) GetSortOrder() string {
@@ -611,7 +663,7 @@ const file_dockyaml_v1_dockyaml_proto_rawDesc = "" +
 	"\bcontents\x18\x01 \x01(\fR\bcontents\"\x10\n" +
 	"\x0eGetYamlRequest\"?\n" +
 	"\x0fGetYamlResponse\x12,\n" +
-	"\x04dock\x18\x01 \x01(\v2\x18.dockyaml.v1.DockmanYamlR\x04dock\"\xbe\x04\n" +
+	"\x04dock\x18\x01 \x01(\v2\x18.dockyaml.v1.DockmanYamlR\x04dock\"\xf6\x04\n" +
 	"\vDockmanYaml\x12K\n" +
 	"\vcustomTools\x18\t \x03(\v2).dockyaml.v1.DockmanYaml.CustomToolsEntryR\vcustomTools\x12,\n" +
 	"\x11useComposeFolders\x18\x01 \x01(\bR\x11useComposeFolders\x12>\n" +
@@ -621,7 +673,9 @@ const file_dockyaml_v1_dockyaml_proto_rawDesc = "" +
 	"\vvolumesPage\x18\x02 \x01(\v2\x1a.dockyaml.v1.VolumesConfigR\vvolumesPage\x12<\n" +
 	"\vnetworkPage\x18\x03 \x01(\v2\x1a.dockyaml.v1.NetworkConfigR\vnetworkPage\x126\n" +
 	"\timagePage\x18\x04 \x01(\v2\x18.dockyaml.v1.ImageConfigR\timagePage\x12B\n" +
-	"\rcontainerPage\x18\x05 \x01(\v2\x1c.dockyaml.v1.ContainerConfigR\rcontainerPage\x1a>\n" +
+	"\rcontainerPage\x18\x05 \x01(\v2\x1c.dockyaml.v1.ContainerConfigR\rcontainerPage\x126\n" +
+	"\tstatsPage\x18\n" +
+	" \x01(\v2\x18.dockyaml.v1.StatsConfigR\tstatsPage\x1a>\n" +
 	"\x10CustomToolsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"6\n" +
@@ -632,6 +686,8 @@ const file_dockyaml_v1_dockyaml_proto_rawDesc = "" +
 	"\vImageConfig\x12%\n" +
 	"\x04sort\x18\x01 \x01(\v2\x11.dockyaml.v1.SortR\x04sort\"8\n" +
 	"\x0fContainerConfig\x12%\n" +
+	"\x04sort\x18\x01 \x01(\v2\x11.dockyaml.v1.SortR\x04sort\"4\n" +
+	"\vStatsConfig\x12%\n" +
 	"\x04sort\x18\x01 \x01(\v2\x11.dockyaml.v1.SortR\x04sort\"B\n" +
 	"\x04Sort\x12\x1c\n" +
 	"\tsortOrder\x18\x01 \x01(\tR\tsortOrder\x12\x1c\n" +
@@ -654,7 +710,7 @@ func file_dockyaml_v1_dockyaml_proto_rawDescGZIP() []byte {
 	return file_dockyaml_v1_dockyaml_proto_rawDescData
 }
 
-var file_dockyaml_v1_dockyaml_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
+var file_dockyaml_v1_dockyaml_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
 var file_dockyaml_v1_dockyaml_proto_goTypes = []any{
 	(*SaveRequest)(nil),     // 0: dockyaml.v1.SaveRequest
 	(*SaveResponse)(nil),    // 1: dockyaml.v1.SaveResponse
@@ -667,31 +723,34 @@ var file_dockyaml_v1_dockyaml_proto_goTypes = []any{
 	(*NetworkConfig)(nil),   // 8: dockyaml.v1.NetworkConfig
 	(*ImageConfig)(nil),     // 9: dockyaml.v1.ImageConfig
 	(*ContainerConfig)(nil), // 10: dockyaml.v1.ContainerConfig
-	(*Sort)(nil),            // 11: dockyaml.v1.Sort
-	nil,                     // 12: dockyaml.v1.DockmanYaml.CustomToolsEntry
+	(*StatsConfig)(nil),     // 11: dockyaml.v1.StatsConfig
+	(*Sort)(nil),            // 12: dockyaml.v1.Sort
+	nil,                     // 13: dockyaml.v1.DockmanYaml.CustomToolsEntry
 }
 var file_dockyaml_v1_dockyaml_proto_depIdxs = []int32{
 	6,  // 0: dockyaml.v1.GetYamlResponse.dock:type_name -> dockyaml.v1.DockmanYaml
-	12, // 1: dockyaml.v1.DockmanYaml.customTools:type_name -> dockyaml.v1.DockmanYaml.CustomToolsEntry
+	13, // 1: dockyaml.v1.DockmanYaml.customTools:type_name -> dockyaml.v1.DockmanYaml.CustomToolsEntry
 	7,  // 2: dockyaml.v1.DockmanYaml.volumesPage:type_name -> dockyaml.v1.VolumesConfig
 	8,  // 3: dockyaml.v1.DockmanYaml.networkPage:type_name -> dockyaml.v1.NetworkConfig
 	9,  // 4: dockyaml.v1.DockmanYaml.imagePage:type_name -> dockyaml.v1.ImageConfig
 	10, // 5: dockyaml.v1.DockmanYaml.containerPage:type_name -> dockyaml.v1.ContainerConfig
-	11, // 6: dockyaml.v1.VolumesConfig.sort:type_name -> dockyaml.v1.Sort
-	11, // 7: dockyaml.v1.NetworkConfig.sort:type_name -> dockyaml.v1.Sort
-	11, // 8: dockyaml.v1.ImageConfig.sort:type_name -> dockyaml.v1.Sort
-	11, // 9: dockyaml.v1.ContainerConfig.sort:type_name -> dockyaml.v1.Sort
-	2,  // 10: dockyaml.v1.DockyamlService.Get:input_type -> dockyaml.v1.GetRequest
-	0,  // 11: dockyaml.v1.DockyamlService.Save:input_type -> dockyaml.v1.SaveRequest
-	4,  // 12: dockyaml.v1.DockyamlService.GetYaml:input_type -> dockyaml.v1.GetYamlRequest
-	3,  // 13: dockyaml.v1.DockyamlService.Get:output_type -> dockyaml.v1.GetResponse
-	1,  // 14: dockyaml.v1.DockyamlService.Save:output_type -> dockyaml.v1.SaveResponse
-	5,  // 15: dockyaml.v1.DockyamlService.GetYaml:output_type -> dockyaml.v1.GetYamlResponse
-	13, // [13:16] is the sub-list for method output_type
-	10, // [10:13] is the sub-list for method input_type
-	10, // [10:10] is the sub-list for extension type_name
-	10, // [10:10] is the sub-list for extension extendee
-	0,  // [0:10] is the sub-list for field type_name
+	11, // 6: dockyaml.v1.DockmanYaml.statsPage:type_name -> dockyaml.v1.StatsConfig
+	12, // 7: dockyaml.v1.VolumesConfig.sort:type_name -> dockyaml.v1.Sort
+	12, // 8: dockyaml.v1.NetworkConfig.sort:type_name -> dockyaml.v1.Sort
+	12, // 9: dockyaml.v1.ImageConfig.sort:type_name -> dockyaml.v1.Sort
+	12, // 10: dockyaml.v1.ContainerConfig.sort:type_name -> dockyaml.v1.Sort
+	12, // 11: dockyaml.v1.StatsConfig.sort:type_name -> dockyaml.v1.Sort
+	2,  // 12: dockyaml.v1.DockyamlService.Get:input_type -> dockyaml.v1.GetRequest
+	0,  // 13: dockyaml.v1.DockyamlService.Save:input_type -> dockyaml.v1.SaveRequest
+	4,  // 14: dockyaml.v1.DockyamlService.GetYaml:input_type -> dockyaml.v1.GetYamlRequest
+	3,  // 15: dockyaml.v1.DockyamlService.Get:output_type -> dockyaml.v1.GetResponse
+	1,  // 16: dockyaml.v1.DockyamlService.Save:output_type -> dockyaml.v1.SaveResponse
+	5,  // 17: dockyaml.v1.DockyamlService.GetYaml:output_type -> dockyaml.v1.GetYamlResponse
+	15, // [15:18] is the sub-list for method output_type
+	12, // [12:15] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_dockyaml_v1_dockyaml_proto_init() }
@@ -705,7 +764,7 @@ func file_dockyaml_v1_dockyaml_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_dockyaml_v1_dockyaml_proto_rawDesc), len(file_dockyaml_v1_dockyaml_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   13,
+			NumMessages:   14,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/core/internal/dockyaml/dockyaml.go
+++ b/core/internal/dockyaml/dockyaml.go
@@ -27,6 +27,12 @@ var defaultDockmanYaml = DockmanYaml{
 			Order: "asc",
 		},
 	},
+	StatsPage: StatsConfig{
+		Sort: Sort{
+			Field: "Memory",
+			Order: "desc",
+		},
+	},
 }
 
 type DockmanYaml struct {
@@ -53,6 +59,9 @@ type DockmanYaml struct {
 
 	ContainerPage ContainerConfig `yaml:"containers"`
 
+	// configure the stats (system resources) page
+	StatsPage StatsConfig `yaml:"stats"`
+
 	// define a max search limit for files
 	SearchLimit int `yaml:"searchLimit"`
 
@@ -72,6 +81,10 @@ type NetworkConfig struct {
 }
 
 type ImageConfig struct {
+	Sort Sort `yaml:"sort"`
+}
+
+type StatsConfig struct {
 	Sort Sort `yaml:"sort"`
 }
 

--- a/core/internal/dockyaml/handler.go
+++ b/core/internal/dockyaml/handler.go
@@ -71,6 +71,7 @@ func (d *DockmanYaml) ToProto() *v1.DockmanYaml {
 		NetworkPage:                d.NetworkPage.toProto(),
 		ImagePage:                  d.ImagePage.toProto(),
 		ContainerPage:              d.ContainerPage.toProto(),
+		StatsPage:                  d.StatsPage.toProto(),
 	}
 }
 
@@ -102,5 +103,11 @@ func (n NetworkConfig) toProto() *v1.NetworkConfig {
 func (i ImageConfig) toProto() *v1.ImageConfig {
 	return &v1.ImageConfig{
 		Sort: i.Sort.toProto(),
+	}
+}
+
+func (st StatsConfig) toProto() *v1.StatsConfig {
+	return &v1.StatsConfig{
+		Sort: st.Sort.toProto(),
 	}
 }

--- a/spec/protos/dockyaml/v1/dockyaml.proto
+++ b/spec/protos/dockyaml/v1/dockyaml.proto
@@ -39,6 +39,7 @@ message DockmanYaml {
   NetworkConfig networkPage = 3;
   ImageConfig imagePage = 4;
   ContainerConfig containerPage = 5;
+  StatsConfig statsPage = 10;
 }
 
 message VolumesConfig {
@@ -54,6 +55,10 @@ message ImageConfig {
 }
 
 message ContainerConfig {
+  Sort sort = 1;
+}
+
+message StatsConfig {
   Sort sort = 1;
 }
 

--- a/ui/src/gen/dockyaml/v1/dockyaml_pb.ts
+++ b/ui/src/gen/dockyaml/v1/dockyaml_pb.ts
@@ -10,7 +10,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file dockyaml/v1/dockyaml.proto.
  */
 export const file_dockyaml_v1_dockyaml: GenFile = /*@__PURE__*/
-  fileDesc("Chpkb2NreWFtbC92MS9kb2NreWFtbC5wcm90bxILZG9ja3lhbWwudjEiHwoLU2F2ZVJlcXVlc3QSEAoIY29udGVudHMYAiABKAwiDgoMU2F2ZVJlc3BvbnNlIgwKCkdldFJlcXVlc3QiHwoLR2V0UmVzcG9uc2USEAoIY29udGVudHMYASABKAwiEAoOR2V0WWFtbFJlcXVlc3QiOQoPR2V0WWFtbFJlc3BvbnNlEiYKBGRvY2sYASABKAsyGC5kb2NreWFtbC52MS5Eb2NrbWFuWWFtbCKrAwoLRG9ja21hbllhbWwSPgoLY3VzdG9tVG9vbHMYCSADKAsyKS5kb2NreWFtbC52MS5Eb2NrbWFuWWFtbC5DdXN0b21Ub29sc0VudHJ5EhkKEXVzZUNvbXBvc2VGb2xkZXJzGAEgASgIEiIKGmRpc2FibGVDb21wb3NlUXVpY2tBY3Rpb25zGAcgASgIEhMKC3NlYXJjaExpbWl0GAggASgFEhAKCHRhYkxpbWl0GAYgASgFEi8KC3ZvbHVtZXNQYWdlGAIgASgLMhouZG9ja3lhbWwudjEuVm9sdW1lc0NvbmZpZxIvCgtuZXR3b3JrUGFnZRgDIAEoCzIaLmRvY2t5YW1sLnYxLk5ldHdvcmtDb25maWcSKwoJaW1hZ2VQYWdlGAQgASgLMhguZG9ja3lhbWwudjEuSW1hZ2VDb25maWcSMwoNY29udGFpbmVyUGFnZRgFIAEoCzIcLmRvY2t5YW1sLnYxLkNvbnRhaW5lckNvbmZpZxoyChBDdXN0b21Ub29sc0VudHJ5EgsKA2tleRgBIAEoCRINCgV2YWx1ZRgCIAEoCToCOAEiMAoNVm9sdW1lc0NvbmZpZxIfCgRzb3J0GAEgASgLMhEuZG9ja3lhbWwudjEuU29ydCIwCg1OZXR3b3JrQ29uZmlnEh8KBHNvcnQYASABKAsyES5kb2NreWFtbC52MS5Tb3J0Ii4KC0ltYWdlQ29uZmlnEh8KBHNvcnQYASABKAsyES5kb2NreWFtbC52MS5Tb3J0IjIKD0NvbnRhaW5lckNvbmZpZxIfCgRzb3J0GAEgASgLMhEuZG9ja3lhbWwudjEuU29ydCIsCgRTb3J0EhEKCXNvcnRPcmRlchgBIAEoCRIRCglzb3J0RmllbGQYAiABKAky1AEKD0RvY2t5YW1sU2VydmljZRI6CgNHZXQSFy5kb2NreWFtbC52MS5HZXRSZXF1ZXN0GhguZG9ja3lhbWwudjEuR2V0UmVzcG9uc2UiABI9CgRTYXZlEhguZG9ja3lhbWwudjEuU2F2ZVJlcXVlc3QaGS5kb2NreWFtbC52MS5TYXZlUmVzcG9uc2UiABJGCgdHZXRZYW1sEhsuZG9ja3lhbWwudjEuR2V0WWFtbFJlcXVlc3QaHC5kb2NreWFtbC52MS5HZXRZYW1sUmVzcG9uc2UiAEKdAQoPY29tLmRvY2t5YW1sLnYxQg1Eb2NreWFtbFByb3RvUAFaLmdpdGh1Yi5jb20vUkEzNDEvZG9ja21hbi9nZW5lcmF0ZWQvZG9ja3lhbWwvdjGiAgNEWFiqAgtEb2NreWFtbC5WMcoCC0RvY2t5YW1sXFYx4gIXRG9ja3lhbWxcVjFcR1BCTWV0YWRhdGHqAgxEb2NreWFtbDo6VjFiBnByb3RvMw");
+  fileDesc("Chpkb2NreWFtbC92MS9kb2NreWFtbC5wcm90bxILZG9ja3lhbWwudjEiHwoLU2F2ZVJlcXVlc3QSEAoIY29udGVudHMYAiABKAwiDgoMU2F2ZVJlc3BvbnNlIgwKCkdldFJlcXVlc3QiHwoLR2V0UmVzcG9uc2USEAoIY29udGVudHMYASABKAwiEAoOR2V0WWFtbFJlcXVlc3QiOQoPR2V0WWFtbFJlc3BvbnNlEiYKBGRvY2sYASABKAsyGC5kb2NreWFtbC52MS5Eb2NrbWFuWWFtbCLYAwoLRG9ja21hbllhbWwSPgoLY3VzdG9tVG9vbHMYCSADKAsyKS5kb2NreWFtbC52MS5Eb2NrbWFuWWFtbC5DdXN0b21Ub29sc0VudHJ5EhkKEXVzZUNvbXBvc2VGb2xkZXJzGAEgASgIEiIKGmRpc2FibGVDb21wb3NlUXVpY2tBY3Rpb25zGAcgASgIEhMKC3NlYXJjaExpbWl0GAggASgFEhAKCHRhYkxpbWl0GAYgASgFEi8KC3ZvbHVtZXNQYWdlGAIgASgLMhouZG9ja3lhbWwudjEuVm9sdW1lc0NvbmZpZxIvCgtuZXR3b3JrUGFnZRgDIAEoCzIaLmRvY2t5YW1sLnYxLk5ldHdvcmtDb25maWcSKwoJaW1hZ2VQYWdlGAQgASgLMhguZG9ja3lhbWwudjEuSW1hZ2VDb25maWcSMwoNY29udGFpbmVyUGFnZRgFIAEoCzIcLmRvY2t5YW1sLnYxLkNvbnRhaW5lckNvbmZpZxIrCglzdGF0c1BhZ2UYCiABKAsyGC5kb2NreWFtbC52MS5TdGF0c0NvbmZpZxoyChBDdXN0b21Ub29sc0VudHJ5EgsKA2tleRgBIAEoCRINCgV2YWx1ZRgCIAEoCToCOAEiMAoNVm9sdW1lc0NvbmZpZxIfCgRzb3J0GAEgASgLMhEuZG9ja3lhbWwudjEuU29ydCIwCg1OZXR3b3JrQ29uZmlnEh8KBHNvcnQYASABKAsyES5kb2NreWFtbC52MS5Tb3J0Ii4KC0ltYWdlQ29uZmlnEh8KBHNvcnQYASABKAsyES5kb2NreWFtbC52MS5Tb3J0IjIKD0NvbnRhaW5lckNvbmZpZxIfCgRzb3J0GAEgASgLMhEuZG9ja3lhbWwudjEuU29ydCIuCgtTdGF0c0NvbmZpZxIfCgRzb3J0GAEgASgLMhEuZG9ja3lhbWwudjEuU29ydCIsCgRTb3J0EhEKCXNvcnRPcmRlchgBIAEoCRIRCglzb3J0RmllbGQYAiABKAky1AEKD0RvY2t5YW1sU2VydmljZRI6CgNHZXQSFy5kb2NreWFtbC52MS5HZXRSZXF1ZXN0GhguZG9ja3lhbWwudjEuR2V0UmVzcG9uc2UiABI9CgRTYXZlEhguZG9ja3lhbWwudjEuU2F2ZVJlcXVlc3QaGS5kb2NreWFtbC52MS5TYXZlUmVzcG9uc2UiABJGCgdHZXRZYW1sEhsuZG9ja3lhbWwudjEuR2V0WWFtbFJlcXVlc3QaHC5kb2NreWFtbC52MS5HZXRZYW1sUmVzcG9uc2UiAEKdAQoPY29tLmRvY2t5YW1sLnYxQg1Eb2NreWFtbFByb3RvUAFaLmdpdGh1Yi5jb20vUkEzNDEvZG9ja21hbi9nZW5lcmF0ZWQvZG9ja3lhbWwvdjGiAgNEWFiqAgtEb2NreWFtbC5WMcoCC0RvY2t5YW1sXFYx4gIXRG9ja3lhbWxcVjFcR1BCTWV0YWRhdGHqAgxEb2NreWFtbDo6VjFiBnByb3RvMw");
 
 /**
  * @generated from message dockyaml.v1.SaveRequest
@@ -150,6 +150,11 @@ export type DockmanYaml = Message<"dockyaml.v1.DockmanYaml"> & {
    * @generated from field: dockyaml.v1.ContainerConfig containerPage = 5;
    */
   containerPage?: ContainerConfig;
+
+  /**
+   * @generated from field: dockyaml.v1.StatsConfig statsPage = 10;
+   */
+  statsPage?: StatsConfig;
 };
 
 /**
@@ -228,6 +233,23 @@ export const ContainerConfigSchema: GenMessage<ContainerConfig> = /*@__PURE__*/
   messageDesc(file_dockyaml_v1_dockyaml, 10);
 
 /**
+ * @generated from message dockyaml.v1.StatsConfig
+ */
+export type StatsConfig = Message<"dockyaml.v1.StatsConfig"> & {
+  /**
+   * @generated from field: dockyaml.v1.Sort sort = 1;
+   */
+  sort?: Sort;
+};
+
+/**
+ * Describes the message dockyaml.v1.StatsConfig.
+ * Use `create(StatsConfigSchema)` to create a new message.
+ */
+export const StatsConfigSchema: GenMessage<StatsConfig> = /*@__PURE__*/
+  messageDesc(file_dockyaml_v1_dockyaml, 11);
+
+/**
  * @generated from message dockyaml.v1.Sort
  */
 export type Sort = Message<"dockyaml.v1.Sort"> & {
@@ -247,7 +269,7 @@ export type Sort = Message<"dockyaml.v1.Sort"> & {
  * Use `create(SortSchema)` to create a new message.
  */
 export const SortSchema: GenMessage<Sort> = /*@__PURE__*/
-  messageDesc(file_dockyaml_v1_dockyaml, 11);
+  messageDesc(file_dockyaml_v1_dockyaml, 12);
 
 /**
  * @generated from service dockyaml.v1.DockyamlService

--- a/ui/src/hooks/docker-containers-stats.ts
+++ b/ui/src/hooks/docker-containers-stats.ts
@@ -3,6 +3,7 @@ import {callRPC, useHostClient} from '../lib/api.ts';
 import {type ContainerStats, DockerService, ORDER, SORT_FIELD} from '../gen/docker/v1/docker_pb.ts';
 import {useSnackbar} from "./snackbar.ts";
 import {useHostStore} from "../pages/compose/state/files.ts";
+import {useConfig} from "./config.ts";
 
 // This map remains very useful for clean, client-side sorting.
 const sortFieldToKeyMap: Record<SORT_FIELD, keyof ContainerStats> = {
@@ -15,10 +16,46 @@ const sortFieldToKeyMap: Record<SORT_FIELD, keyof ContainerStats> = {
     [SORT_FIELD.DISK_W]: 'blockWrite',
 };
 
+// Maps a dockman.yml `stats.sort.field` string to a SORT_FIELD. Accepts the
+// column labels and a few obvious aliases, case-insensitively. Falls back to
+// MEM, preserving the historical default.
+const configFieldToSortField = (field?: string): SORT_FIELD => {
+    switch ((field ?? '').trim().toLowerCase()) {
+        case 'name':
+        case 'container':
+            return SORT_FIELD.NAME;
+        case 'cpu':
+        case 'cpu usage':
+            return SORT_FIELD.CPU;
+        case 'mem':
+        case 'memory':
+        case 'memory usage':
+            return SORT_FIELD.MEM;
+        case 'network_rx':
+        case 'rx':
+            return SORT_FIELD.NETWORK_RX;
+        case 'network_tx':
+        case 'tx':
+            return SORT_FIELD.NETWORK_TX;
+        case 'disk_r':
+        case 'disk read':
+            return SORT_FIELD.DISK_R;
+        case 'disk_w':
+        case 'disk write':
+            return SORT_FIELD.DISK_W;
+        default:
+            return SORT_FIELD.MEM;
+    }
+};
+
+const configOrderToOrder = (order?: string): ORDER =>
+    (order ?? '').trim().toLowerCase() === 'asc' ? ORDER.ASC : ORDER.DSC;
+
 export function useDockerStats(selectedPage?: string) {
     const dockerService = useHostClient(DockerService)
     const {showError} = useSnackbar();
     const selectedHost = useHostStore(state => state.host)
+    const {dockYaml} = useConfig();
 
     const [rawContainers, setRawContainers] = useState<ContainerStats[]>([]);
     const [loading, setLoading] = useState(true);
@@ -28,6 +65,18 @@ export function useDockerStats(selectedPage?: string) {
     const [refreshInterval, setRefreshInterval] = useState(2500);
     const isInitialLoad = useRef(true);
     const resort = useRef(false)
+    // Once the user sorts by hand we stop applying the dockman.yml default so a
+    // late-arriving (or per-host) config never clobbers their choice.
+    const userSorted = useRef(false)
+
+    // Seed the sort from dockman.yml (stats.sort) until the user sorts manually.
+    useEffect(() => {
+        if (userSorted.current) return;
+        const cfg = dockYaml?.statsPage?.sort;
+        if (!cfg) return;
+        setSortField(configFieldToSortField(cfg.sortField));
+        setSortOrder(configOrderToOrder(cfg.sortOrder));
+    }, [dockYaml]);
 
     useEffect(() => {
         let isCancelled = false;
@@ -69,6 +118,8 @@ export function useDockerStats(selectedPage?: string) {
         setRawContainers([])
         setLoading(true)
         isInitialLoad.current = true;
+        // re-apply the configured default for the newly selected host
+        userSorted.current = false;
     }, [selectedHost]);
 
     // Optimistic Client-Side Sorting
@@ -101,6 +152,7 @@ export function useDockerStats(selectedPage?: string) {
 
 
     const handleSortChange = useCallback((newField: SORT_FIELD, newOrderBy: ORDER) => {
+        userSorted.current = true
         setSortField(newField)
         setSortOrder(newOrderBy)
         // immediate resort for ui


### PR DESCRIPTION
## Problem

The **System Resources (stats)** view was the only list that ignored
`dockman.yml`: `useDockerStats` hard-coded `MEM` / `desc` and never read the
config, and `DockmanYaml` had no stats page — so a `stats.sort` block did
nothing.

## Fix

- Add a `StatsConfig` (`statsPage`) to the dockyaml proto and `DockmanYaml`,
  defaulting to `Memory` / `desc` to preserve current behaviour.
- `useDockerStats` seeds its sort from `dockYaml.statsPage.sort` (mapping the
  field string to `SORT_FIELD` and the order to `ORDER`) until the user sorts
  by hand; the default re-applies per host.

```yaml
stats:
  sort:
    order: asc      # asc | desc
    field: Name     # Name | CPU | Memory (case-insensitive)
```

## Note

Includes regenerated protobuf stubs (`dockyaml.pb.go`, `dockyaml_pb.ts`),
produced with the pinned plugin versions from the existing generated headers
(`protoc-gen-go v1.36.11`, `protoc-gen-es v2.11.0`). Happy to regenerate with
your exact toolchain if the diff differs.

## Testing

Verified on a homelab: a `stats.sort` block sorts the view on load by the
configured field/order.

Closes https://github.com/RA341/dockman/issues/90