### PR TITLE
fix(tables): apply the dockman.yml sort config and header arrow on load

### DIFF
--- a/ui/src/lib/table.ts
+++ b/ui/src/lib/table.ts
@@ -1,4 +1,4 @@
-import {type JSX, useCallback, useEffect, useMemo, useState} from "react";
+import {type JSX, useCallback, useEffect, useMemo, useRef, useState} from "react";
 import {callRPC, useHostClient} from "./api.ts";
 import {type DockmanYaml, DockyamlService} from "../gen/dockyaml/v1/dockyaml_pb.ts";
 
@@ -63,8 +63,22 @@ export function useSelection<T>(
 export const useSort = (initialField: string, initialSort: SortOrder = 'asc') => {
     const [sortField, setSortField] = useState<string>(initialField);
     const [sortOrder, setSortOrder] = useState<SortOrder>(initialSort);
+    // Stops the config from re-seeding once the user picks a column by hand.
+    const userSorted = useRef(false);
+
+    // The dockman.yml config that feeds initialField/initialSort is fetched
+    // asynchronously, so it typically lands AFTER the first render — when
+    // useState has already locked in the fallback. Without this, the configured
+    // column/order (and its header sort arrow) never take effect until the user
+    // clicks a header. Re-seed from the config until they sort manually.
+    useEffect(() => {
+        if (userSorted.current) return;
+        setSortField(initialField);
+        setSortOrder(initialSort);
+    }, [initialField, initialSort]);
 
     const handleSort = (field: string) => {
+        userSorted.current = true;
         if (sortField === field) {
             setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc');
         } else {

--- a/ui/src/pages/networks/networks-table.tsx
+++ b/ui/src/pages/networks/networks-table.tsx
@@ -57,7 +57,7 @@ export const NetworkTable = ({networks, selectedNetworks = [], onSelectionChange
     };
 
     const {sortField, sortOrder, handleSort} = useSort(
-        dockYaml?.networkPage?.sort?.sortField ?? 'Name',
+        dockYaml?.networkPage?.sort?.sortField ?? 'Network Name',
         (dockYaml?.networkPage?.sort?.sortOrder as SortOrder) ?? 'asc'
     );
 
@@ -79,13 +79,16 @@ export const NetworkTable = ({networks, selectedNetworks = [], onSelectionChange
                 </TableCell>
             )
         },
-        Name: {
+        // Key must match the dockman.yml field name ("Network Name", the backend
+        // default) so a configured sort lights up the header arrow; the label is
+        // hardcoded to keep the column header short, like the columns below.
+        "Network Name": {
             getValue: (n) => n.name,
             header: (label) => (
                 <TableCell sx={headerStyles}>
                     <TableSortLabel active={sortField === label} direction={sortOrder}
                                     onClick={() => handleSort(label)}>
-                        {label}
+                        Name
                     </TableSortLabel>
                 </TableCell>
             ),


### PR DESCRIPTION
## Problem

Two issues kept the `dockman.yml` sort config from fully taking effect on the
resource lists:

1. **Config applied late.** `useSort` seeded its state from
   `initialField`/`initialSort` with `useState`, but the config that feeds
   those is fetched asynchronously and usually arrives *after* the first render
   — so `useState` kept the fallback. The list then sorted by the wrong
   column/order (masked on the name column by `sortTable`'s index-1 fallback)
   and the header sort arrow never lit up until a header was clicked.

2. **Networks key mismatch.** The networks list keyed its name column `"Name"`
   while the configured field (and the backend default) is `"Network Name"`, so
   `active={sortField === label}` never matched and the arrow was missing even
   once the config loaded.

## Fix

- Re-seed `sortField`/`sortOrder` from the config via an effect until the user
  sorts manually — fixes the volumes, networks, images and containers lists at
  once.
- Key the networks name column `"Network Name"` to match the config (the header
  label stays "Name").

## Testing

Verified on a homelab: with e.g. `networks.sort: {order: desc, field: Network
Name}`, the Networks view loads sorted with the header arrow visible; the same
holds for the other lists.
