### PR TITLE
feat(files): sort the file tree folders-first, case-insensitive (VS Code style)

### DIFF
--- a/core/internal/files/service.go
+++ b/core/internal/files/service.go
@@ -611,33 +611,41 @@ func (s *Service) sortFiles(a, b *Entry, host string) int {
 	if ra > rb {
 		return 1
 	}
-	return strings.Compare(a.fullpath, b.fullpath)
+
+	// Same rank: compare names case-insensitively (VS Code style), falling back
+	// to a case-sensitive compare so entries differing only by case stay in a
+	// deterministic order. A dotfile's leading "." naturally floats it to the
+	// top of its group.
+	an, bn := filepath.Base(a.fullpath), filepath.Base(b.fullpath)
+	if c := strings.Compare(strings.ToLower(an), strings.ToLower(bn)); c != 0 {
+		return c
+	}
+	return strings.Compare(an, bn)
 }
 
-// getSortRank determines priority: dotfiles, directories, then files by getFileSortRank
+// getSortRank orders entries folders-first, then files: pinned files win (in
+// their configured order), then directories, then files (with a small bias so
+// compose/yaml files surface first). Dotfiles are NOT a separate group — the
+// case-insensitive name compare in sortFiles floats them to the top of their
+// own group, matching the folders-first behaviour of editors like VS Code.
 func (s *Service) getSortRank(entry *Entry, host string) int {
 	conf := s.dockYml(host)
 
 	base := filepath.Base(entry.fullpath)
-	// -1: pinned files (highest priority)
+	// Pinned files (explicit user-defined order) always come first.
 	if priority, ok := conf.PinnedFiles[base]; ok {
 		// potential bug, but if someone is manually writing the order of 100000 files i say get a life
 		// -999 > -12 in this context, pretty stupid but i cant be bothered to fix this mathematically
 		return priority - 100_000
 	}
 
-	// 0: dotfiles (highest priority)
-	if strings.HasPrefix(base, ".") {
-		return 1
-	}
-
-	// Check if it's a directory (has subfiles)
+	// Directories before files.
 	if entry.isDir {
-		return 2
+		return 0
 	}
 
-	// 2+: normal files, ranked by getFileSortRank
-	return 3 + s.getFileSortRank(entry.fullpath)
+	// Files, ranked so compose/yaml files surface first within the group.
+	return 1 + s.getFileSortRank(entry.fullpath)
 }
 
 // getFileSortRank assigns priority within normal files

--- a/core/internal/files/service_test.go
+++ b/core/internal/files/service_test.go
@@ -5,9 +5,11 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
+	"github.com/RA341/dockman/internal/dockyaml"
 	"github.com/RA341/dockman/internal/host/filesystem"
 	"github.com/stretchr/testify/require"
 )
@@ -53,6 +55,65 @@ func TestTemplateRead(t *testing.T) {
 		require.NoError(t, err)
 		break
 	}
+}
+
+func sortNames(srv *Service, entries []Entry) []string {
+	slices.SortFunc(entries, func(a, b Entry) int {
+		return srv.sortFiles(&a, &b, "local")
+	})
+	names := make([]string, len(entries))
+	for i, e := range entries {
+		names[i] = e.fullpath
+	}
+	return names
+}
+
+func dirEntry(name string) Entry  { return Entry{fullpath: name, isDir: true} }
+func fileEntry(name string) Entry { return Entry{fullpath: name, isDir: false} }
+
+// TestSortFoldersFirst covers the VS Code-style ordering: folders first, then
+// files, each case-insensitive, with dotfiles floating to the top of their own
+// group rather than forming a separate group above the directories.
+func TestSortFoldersFirst(t *testing.T) {
+	srv := &Service{dockYml: func(string) *dockyaml.DockmanYaml { return &dockyaml.DockmanYaml{} }}
+
+	// Same set as the bytebot repo root, shuffled.
+	input := []Entry{
+		fileEntry("README.md"), dirEntry("docker"), fileEntry(".gitignore"), dirEntry("static"),
+		dirEntry(".github"), fileEntry("LICENSE"), dirEntry("helm"), dirEntry(".git"),
+		dirEntry("packages"), fileEntry(".prettierignore"), dirEntry("docs"),
+	}
+
+	want := []string{
+		// directories first (dotfolders float to the top), case-insensitive
+		".git", ".github", "docker", "docs", "helm", "packages", "static",
+		// then files (dotfiles float to the top), case-insensitive
+		".gitignore", ".prettierignore", "LICENSE", "README.md",
+	}
+	require.Equal(t, want, sortNames(srv, input))
+}
+
+// TestSortComposePinnedAndCase covers the Dockman-specific extras kept on top
+// of the VS Code ordering: pinned files win outright, compose/yaml files
+// surface first within the files group, and case is ignored ("Backups" < "data").
+func TestSortComposePinnedAndCase(t *testing.T) {
+	srv := &Service{dockYml: func(string) *dockyaml.DockmanYaml {
+		return &dockyaml.DockmanYaml{PinnedFiles: map[string]int{"notes.md": 0}}
+	}}
+
+	input := []Entry{
+		fileEntry("app.env"), dirEntry("data"), fileEntry("values.yaml"), dirEntry("Backups"),
+		fileEntry("compose.yaml"), fileEntry("notes.md"), fileEntry(".env"),
+	}
+
+	want := []string{
+		"notes.md",           // pinned wins over everything
+		"Backups", "data",    // folders, case-insensitive
+		"compose.yaml",       // files: compose first
+		"values.yaml",        // then other yaml
+		".env", "app.env",    // then remaining files, case-insensitive (dot floats)
+	}
+	require.Equal(t, want, sortNames(srv, input))
 }
 
 func CreateRandomDirStructure(rootDir string, maxDepth int) (string, error) {


### PR DESCRIPTION
## Problem

The file tree grouped **all** dotfiles and dot-folders into a single bucket
ranked above regular directories, so a dotfile (e.g. `.gitignore`) sorted
before a real folder (`docker/`) — mixing the folders-first rule the rest of
the list followed. Ties were also broken case-sensitively.

## Fix

Rank directories before files and drop the dotfile special case: a leading
`.` now floats an entry to the top of its own group (folders or files) via a
case-insensitive name compare, matching editors like VS Code.

- Pinned files (`pinnedFiles`) still win outright.
- Compose/yaml files still surface first within the files group.

## Example (a repo root)

```
📁 .git  .github  docker  docs  helm  packages  static      ← folders
📄 .gitignore  .prettierignore  LICENSE  README.md          ← files
```

## Testing

Adds unit tests pinning the resulting order (folders-first, case-insensitive,
dotfiles floating, plus the pinned / compose cases).
