### PR TITLE
fix(volumes): detect volume usage from all containers

### DIFF
--- a/core/internal/docker/container/volumes.go
+++ b/core/internal/docker/container/volumes.go
@@ -45,18 +45,19 @@ func (s *Service) VolumesList(ctx context.Context) ([]VolumeInfo, error) {
 		}
 	}
 
-	volumeFilters := client.Filters{}
 	for i, vol := range listResp.Items {
-		val, ok := tmpMap[vol.Name]
-		if ok {
+		if val, ok := tmpMap[vol.Name]; ok {
 			listResp.Items[i] = val
 		}
-		volumeFilters.Add("volume", val.Name)
 	}
 
+	// List every container and derive volume usage from their mounts. A prior
+	// version filtered containers by the volume names reported in disk usage,
+	// but a volume missing from disk usage (e.g. a CIFS/network volume with no
+	// reported size) was then never matched to its container and shown as
+	// "Unused" even while mounted.
 	containers, err := s.Client.ContainerList(ctx, client.ContainerListOptions{
-		All:     true,
-		Filters: volumeFilters,
+		All: true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list containers: %w", err)


### PR DESCRIPTION
## Problem

The volumes list built its container query from a `volume=` filter populated
with the volume names reported by **disk usage**. A volume absent from disk
usage — e.g. a CIFS/network volume with no reported size (shows `0 B`) — was
never added to the filter, so the container mounting it wasn't returned and
the volume was shown as **"Unused"** despite being mounted.

## Fix

List all containers and derive volume usage from their mounts, instead of
relying on the disk-usage-derived filter. The `In Use` status is now accurate
for volumes that disk usage doesn't report.

## Testing

Verified on a homelab with a CIFS volume (`0 B`, mounted by a container): it
now correctly shows as `In Use`.
