### PR TITLE
feat(files): drag entries back to the tree root via a drag-only drop banner

### DIFF
--- a/ui/src/pages/compose/components/file-item.tsx
+++ b/ui/src/pages/compose/components/file-item.tsx
@@ -77,8 +77,7 @@ export const useFileDnD = (entry: FsEntry) => {
         if (sourcePath) {
             if (sourcePath === entry.filename) return; // Can't drop on self
             const fileName = sourcePath.split('/').pop() || "";
-            // At the root targetDir is "" — avoid producing a leading-slash "/name".
-            const newPath = targetDir === "" ? fileName : `${targetDir}/${fileName}`;
+            const newPath = `${targetDir}/${fileName}`;
             // Only trigger if the path actually changes
             if (sourcePath !== newPath) {
                 await renameFile(sourcePath, newPath);

--- a/ui/src/pages/compose/components/file-item.tsx
+++ b/ui/src/pages/compose/components/file-item.tsx
@@ -24,7 +24,7 @@ import {useSnackbar} from "../../../hooks/snackbar.ts";
 import {useFileCreate} from "../dialogs/file-create.tsx";
 import {useFileDelete} from "../dialogs/file-delete.tsx";
 import {useFileRename} from "../dialogs/file-rename.tsx";
-import {useAliasStore, useHostStore, useOpenFiles} from "../state/files.ts";
+import {useAliasStore, useFileDrag, useHostStore, useOpenFiles} from "../state/files.ts";
 import {useConfig} from "../../../hooks/config.ts";
 import {useComposeFileState} from "../state/status.ts";
 import {getContextKey} from "../../../context/tab-context.tsx";
@@ -35,10 +35,18 @@ import {stripQueryParams} from "../../../lib/strings.ts";
 export const useFileDnD = (entry: FsEntry) => {
     const [isDragOver, setIsDragOver] = useState(false);
     const {renameFile, uploadFilesFromPC} = useFiles();
+    const setDragging = useFileDrag(state => state.setDragging);
 
     const handleDragStart = (e: React.DragEvent) => {
         e.dataTransfer.setData("sourcePath", entry.filename);
         e.dataTransfer.effectAllowed = "move";
+        // Signal a drag is in progress so the transient "drop to root" banner appears.
+        setDragging(true);
+    };
+
+    const handleDragEnd = () => {
+        // Always clear the flag when the drag ends (dropped or cancelled).
+        setDragging(false);
     };
 
     const handleDragOver = (e: React.DragEvent) => {
@@ -69,7 +77,8 @@ export const useFileDnD = (entry: FsEntry) => {
         if (sourcePath) {
             if (sourcePath === entry.filename) return; // Can't drop on self
             const fileName = sourcePath.split('/').pop() || "";
-            const newPath = `${targetDir}/${fileName}`;
+            // At the root targetDir is "" — avoid producing a leading-slash "/name".
+            const newPath = targetDir === "" ? fileName : `${targetDir}/${fileName}`;
             // Only trigger if the path actually changes
             if (sourcePath !== newPath) {
                 await renameFile(sourcePath, newPath);
@@ -89,6 +98,7 @@ export const useFileDnD = (entry: FsEntry) => {
         dndProps: {
             draggable: true,
             onDragStart: handleDragStart,
+            onDragEnd: handleDragEnd,
             onDragOver: handleDragOver,
             onDragLeave: handleDragLeave,
             onDrop: handleDrop,

--- a/ui/src/pages/compose/components/file-list.tsx
+++ b/ui/src/pages/compose/components/file-list.tsx
@@ -84,8 +84,9 @@ export function FileList() {
                      overflow: 'hidden', // Keeps the header and resize handle fixed
                  }}
             >
-                {/* HEADER AREA */}
-                <Toolbar variant="dense" sx={{px: 1, gap: 1}}>
+                {/* HEADER AREA — also hosts the transient root-drop overlay */}
+                <Toolbar variant="dense" sx={{px: 1, gap: 1, position: 'relative'}}>
+                    <RootDropZone/>
                     <Box
                         sx={{
                             display: 'flex',
@@ -137,28 +138,16 @@ export function FileList() {
 
                 <Divider/>
 
-                {/* List area: a flex column so the transient root-drop banner sits
-                    above the scroll area (pushing it down) instead of overlapping
-                    the first row while dragging. */}
-                <Box sx={{
+                <Box ref={autoScroll} sx={{
                     flexGrow: 1,
                     minHeight: 0,
-                    display: 'flex',
-                    flexDirection: 'column',
-                    overflow: 'hidden',
+                    overflowY: 'auto',
+                    overflowX: 'hidden',
+                    scrollbarGutter: 'stable',
+                    '&::-webkit-scrollbar': {width: '6px'},
+                    '&::-webkit-scrollbar-thumb': {backgroundColor: 'rgba(255,255,255,0.1)'}
                 }}>
-                    <RootDropZone/>
-                    <Box ref={autoScroll} sx={{
-                        flexGrow: 1,
-                        minHeight: 0,
-                        overflowY: 'auto',
-                        overflowX: 'hidden',
-                        scrollbarGutter: 'stable',
-                        '&::-webkit-scrollbar': {width: '6px'},
-                        '&::-webkit-scrollbar-thumb': {backgroundColor: 'rgba(255,255,255,0.1)'}
-                    }}>
-                        <FileListInner/>
-                    </Box>
+                    <FileListInner/>
                 </Box>
 
                 {/* Resize Handle */}

--- a/ui/src/pages/compose/components/file-list.tsx
+++ b/ui/src/pages/compose/components/file-list.tsx
@@ -137,12 +137,12 @@ export function FileList() {
 
                 <Divider/>
 
-                {/* List area: a relative wrapper so the transient root-drop banner
-                    can overlay the top without scrolling or reflowing the list. */}
+                {/* List area: a flex column so the transient root-drop banner sits
+                    above the scroll area (pushing it down) instead of overlapping
+                    the first row while dragging. */}
                 <Box sx={{
                     flexGrow: 1,
                     minHeight: 0,
-                    position: 'relative',
                     display: 'flex',
                     flexDirection: 'column',
                     overflow: 'hidden',

--- a/ui/src/pages/compose/components/file-list.tsx
+++ b/ui/src/pages/compose/components/file-list.tsx
@@ -10,6 +10,8 @@ import {useFileSearch} from "../dialogs/file-search.tsx";
 import {useFileCreate} from "../dialogs/file-create.tsx";
 import {useSideBarAction} from "../state/files.ts";
 import {YamlIcon} from "./file-icon.tsx";
+import {RootDropZone} from "./root-drop-zone.tsx";
+import {useDragAutoScroll} from "../hooks/drag-autoscroll.ts";
 import {useNavigate} from "react-router-dom";
 import {useEditorUrl} from "../../../lib/editor.ts";
 import {formatDockyaml} from "./viewer-dockyml.tsx";
@@ -63,6 +65,7 @@ export function FileList() {
     }, [])
 
     const {panelSize, panelRef, handleMouseDown, isResizing} = useResizeBar('right')
+    const autoScroll = useDragAutoScroll()
 
     return (
         <>
@@ -134,15 +137,28 @@ export function FileList() {
 
                 <Divider/>
 
+                {/* List area: a relative wrapper so the transient root-drop banner
+                    can overlay the top without scrolling or reflowing the list. */}
                 <Box sx={{
                     flexGrow: 1,
-                    overflowY: 'auto',
-                    overflowX: 'hidden',
-                    scrollbarGutter: 'stable',
-                    '&::-webkit-scrollbar': {width: '6px'},
-                    '&::-webkit-scrollbar-thumb': {backgroundColor: 'rgba(255,255,255,0.1)'}
+                    minHeight: 0,
+                    position: 'relative',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    overflow: 'hidden',
                 }}>
-                    <FileListInner/>
+                    <RootDropZone/>
+                    <Box ref={autoScroll} sx={{
+                        flexGrow: 1,
+                        minHeight: 0,
+                        overflowY: 'auto',
+                        overflowX: 'hidden',
+                        scrollbarGutter: 'stable',
+                        '&::-webkit-scrollbar': {width: '6px'},
+                        '&::-webkit-scrollbar-thumb': {backgroundColor: 'rgba(255,255,255,0.1)'}
+                    }}>
+                        <FileListInner/>
+                    </Box>
                 </Box>
 
                 {/* Resize Handle */}

--- a/ui/src/pages/compose/components/root-drop-zone.tsx
+++ b/ui/src/pages/compose/components/root-drop-zone.tsx
@@ -9,9 +9,11 @@ import {useFileComponents} from "../state/terminal.tsx";
 // dragged. It lets you move an entry back to the root of the tree — otherwise
 // impossible when the root has no sibling file to drop onto.
 //
-// It is rendered in-flow (only during a drag) so it never overlaps the first
-// row: when it appears it pushes the list down, keeping every folder reachable
-// as a drop target. Outside of a drag it renders nothing, taking no space.
+// It is rendered as an ABSOLUTE overlay covering the file-list header (the alias
+// bar), so it never overlaps a file row and — crucially — never shifts the list
+// layout. Shifting the list during a drag moves the dragged row and makes the
+// browser cancel the drag; an absolute overlay avoids that entirely. The parent
+// header must be position:relative.
 export function RootDropZone() {
     const dragging = useFileDrag(state => state.dragging);
     const setDragging = useFileDrag(state => state.setDragging);
@@ -60,18 +62,20 @@ export function RootDropZone() {
             onDragLeave={handleDragLeave}
             onDrop={handleDrop}
             sx={{
-                flexShrink: 0,
-                m: 0.75,
-                height: 32,
+                position: 'absolute',
+                inset: 0,
+                zIndex: 6,
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'center',
                 gap: 0.75,
+                px: 1,
+                backgroundColor: isOver ? 'rgba(144,202,249,0.22)' : 'rgba(30,30,30,0.97)',
+                color: isOver ? 'primary.main' : 'rgba(255,255,255,0.85)',
+                border: '2px dashed',
+                borderColor: isOver ? 'primary.main' : 'rgba(255,255,255,0.4)',
                 borderRadius: 1,
-                border: '1.5px dashed',
-                borderColor: isOver ? 'primary.main' : 'rgba(255,255,255,0.35)',
-                backgroundColor: isOver ? 'rgba(144,202,249,0.18)' : 'rgba(255,255,255,0.04)',
-                color: isOver ? 'primary.main' : 'rgba(255,255,255,0.7)',
+                cursor: 'copy',
                 transition: 'background-color 80ms, border-color 80ms, color 80ms',
             }}
         >

--- a/ui/src/pages/compose/components/root-drop-zone.tsx
+++ b/ui/src/pages/compose/components/root-drop-zone.tsx
@@ -1,16 +1,17 @@
 import React, {useState} from "react";
 import {Box, Typography} from "@mui/material";
 import {VerticalAlignTop as MoveToRootIcon} from "@mui/icons-material";
-import {getDir, getEntryDisplayName, useFiles} from "../../../context/file-context.tsx";
+import {useFiles} from "../../../context/file-context.tsx";
 import {useFileDrag} from "../state/files.ts";
 import {useFileComponents} from "../state/terminal.tsx";
 
 // RootDropZone is a drop target that only exists while a file-tree entry is being
 // dragged. It lets you move an entry back to the root of the tree — otherwise
-// impossible when the root has no sibling file to drop onto. It is rendered as an
-// absolute overlay so it takes no layout space (and causes no reflow) outside of a
-// drag, and it stays pinned to the top of the list area so it is always reachable
-// without scrolling.
+// impossible when the root has no sibling file to drop onto.
+//
+// It is rendered in-flow (only during a drag) so it never overlaps the first
+// row: when it appears it pushes the list down, keeping every folder reachable
+// as a drop target. Outside of a drag it renders nothing, taking no space.
 export function RootDropZone() {
     const dragging = useFileDrag(state => state.dragging);
     const setDragging = useFileDrag(state => state.setDragging);
@@ -41,13 +42,16 @@ export function RootDropZone() {
 
         const sourcePath = e.dataTransfer.getData("sourcePath");
         if (!sourcePath) return;
-        // Already at the root (no parent directory) -> nothing to do.
-        if (getDir(sourcePath) === "") return;
 
-        const newPath = getEntryDisplayName(sourcePath);
-        if (newPath && newPath !== sourcePath) {
-            await renameFile(sourcePath, newPath);
-        }
+        // Tree paths are "<alias>/<relpath>": the first segment is the alias (the
+        // tree root), NOT part of the file path. A root move therefore keeps the
+        // alias prefix and drops everything in between -> "<alias>/<basename>".
+        const parts = sourcePath.split("/").filter(Boolean);
+        // Already at the root (only "<alias>/<name>") -> nothing to do.
+        if (parts.length <= 2) return;
+
+        const newPath = `${parts[0]}/${parts[parts.length - 1]}`;
+        await renameFile(sourcePath, newPath);
     };
 
     return (
@@ -56,12 +60,9 @@ export function RootDropZone() {
             onDragLeave={handleDragLeave}
             onDrop={handleDrop}
             sx={{
-                position: 'absolute',
-                top: 6,
-                left: 6,
-                right: 6,
-                zIndex: 20,
-                height: 34,
+                flexShrink: 0,
+                m: 0.75,
+                height: 32,
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'center',
@@ -69,11 +70,9 @@ export function RootDropZone() {
                 borderRadius: 1,
                 border: '1.5px dashed',
                 borderColor: isOver ? 'primary.main' : 'rgba(255,255,255,0.35)',
-                backgroundColor: isOver ? 'rgba(144,202,249,0.18)' : 'rgba(30,30,30,0.94)',
-                color: isOver ? 'primary.main' : 'rgba(255,255,255,0.75)',
-                boxShadow: '0 2px 6px rgba(0,0,0,0.4)',
+                backgroundColor: isOver ? 'rgba(144,202,249,0.18)' : 'rgba(255,255,255,0.04)',
+                color: isOver ? 'primary.main' : 'rgba(255,255,255,0.7)',
                 transition: 'background-color 80ms, border-color 80ms, color 80ms',
-                pointerEvents: 'auto',
             }}
         >
             <MoveToRootIcon sx={{fontSize: 18}}/>

--- a/ui/src/pages/compose/components/root-drop-zone.tsx
+++ b/ui/src/pages/compose/components/root-drop-zone.tsx
@@ -1,0 +1,87 @@
+import React, {useState} from "react";
+import {Box, Typography} from "@mui/material";
+import {VerticalAlignTop as MoveToRootIcon} from "@mui/icons-material";
+import {getDir, getEntryDisplayName, useFiles} from "../../../context/file-context.tsx";
+import {useFileDrag} from "../state/files.ts";
+import {useFileComponents} from "../state/terminal.tsx";
+
+// RootDropZone is a drop target that only exists while a file-tree entry is being
+// dragged. It lets you move an entry back to the root of the tree — otherwise
+// impossible when the root has no sibling file to drop onto. It is rendered as an
+// absolute overlay so it takes no layout space (and causes no reflow) outside of a
+// drag, and it stays pinned to the top of the list area so it is always reachable
+// without scrolling.
+export function RootDropZone() {
+    const dragging = useFileDrag(state => state.dragging);
+    const setDragging = useFileDrag(state => state.setDragging);
+    const {renameFile} = useFiles();
+    const {alias} = useFileComponents();
+    const [isOver, setIsOver] = useState(false);
+
+    // Nothing to show unless an internal drag is in progress.
+    if (!dragging) return null;
+
+    const handleDragOver = (e: React.DragEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        setIsOver(true);
+    };
+
+    const handleDragLeave = (e: React.DragEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        setIsOver(false);
+    };
+
+    const handleDrop = async (e: React.DragEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        setIsOver(false);
+        setDragging(false);
+
+        const sourcePath = e.dataTransfer.getData("sourcePath");
+        if (!sourcePath) return;
+        // Already at the root (no parent directory) -> nothing to do.
+        if (getDir(sourcePath) === "") return;
+
+        const newPath = getEntryDisplayName(sourcePath);
+        if (newPath && newPath !== sourcePath) {
+            await renameFile(sourcePath, newPath);
+        }
+    };
+
+    return (
+        <Box
+            onDragOver={handleDragOver}
+            onDragLeave={handleDragLeave}
+            onDrop={handleDrop}
+            sx={{
+                position: 'absolute',
+                top: 6,
+                left: 6,
+                right: 6,
+                zIndex: 20,
+                height: 34,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: 0.75,
+                borderRadius: 1,
+                border: '1.5px dashed',
+                borderColor: isOver ? 'primary.main' : 'rgba(255,255,255,0.35)',
+                backgroundColor: isOver ? 'rgba(144,202,249,0.18)' : 'rgba(30,30,30,0.94)',
+                color: isOver ? 'primary.main' : 'rgba(255,255,255,0.75)',
+                boxShadow: '0 2px 6px rgba(0,0,0,0.4)',
+                transition: 'background-color 80ms, border-color 80ms, color 80ms',
+                pointerEvents: 'auto',
+            }}
+        >
+            <MoveToRootIcon sx={{fontSize: 18}}/>
+            <Typography variant="caption" fontWeight={600} noWrap>
+                Move to {alias || 'root'}
+            </Typography>
+        </Box>
+    );
+}
+
+export default RootDropZone;

--- a/ui/src/pages/compose/hooks/drag-autoscroll.ts
+++ b/ui/src/pages/compose/hooks/drag-autoscroll.ts
@@ -1,0 +1,81 @@
+import {useCallback, useEffect, useRef} from "react";
+
+// useDragAutoScroll returns a callback ref to attach to a scrollable element.
+// While a drag hovers within EDGE px of the element's top or bottom edge, the
+// element auto-scrolls in that direction, so you can drag an entry from the
+// bottom of a long list up to a folder (or the root banner) at the top, and
+// vice-versa.
+//
+// Listeners are attached in the capture phase because the file rows call
+// stopPropagation on their own dragover handlers, which would otherwise stop a
+// bubbling listener on the container from ever firing while the pointer is over
+// a row. A callback ref (rather than a plain ref + effect) re-attaches cleanly
+// when the underlying node is swapped out (e.g. toggling pinned mode).
+export function useDragAutoScroll() {
+    const cleanupRef = useRef<(() => void) | null>(null);
+
+    const setNode = useCallback((el: HTMLElement | null) => {
+        // Detach from any previously attached node.
+        cleanupRef.current?.();
+        cleanupRef.current = null;
+        if (!el) return;
+
+        const EDGE = 40;   // px from an edge that starts scrolling
+        const STEP = 10;   // px scrolled per tick
+        let timer: number | null = null;
+        let dir = 0;       // -1 up, +1 down, 0 idle
+
+        const stop = () => {
+            dir = 0;
+            if (timer !== null) {
+                clearInterval(timer);
+                timer = null;
+            }
+        };
+
+        const onDragOver = (e: DragEvent) => {
+            const rect = el.getBoundingClientRect();
+            const y = e.clientY;
+            if (y < rect.top + EDGE) dir = -1;
+            else if (y > rect.bottom - EDGE) dir = 1;
+            else {
+                stop();
+                return;
+            }
+            if (timer === null) {
+                timer = window.setInterval(() => {
+                    el.scrollTop += dir * STEP;
+                }, 16);
+            }
+        };
+
+        const onDragLeave = (e: DragEvent) => {
+            // Only stop when the pointer actually leaves the container (relatedTarget
+            // outside it), not when moving between the rows inside it.
+            const to = e.relatedTarget as Node | null;
+            if (!to || !el.contains(to)) stop();
+        };
+
+        el.addEventListener("dragover", onDragOver, true);
+        el.addEventListener("dragleave", onDragLeave, true);
+        window.addEventListener("dragend", stop);
+        window.addEventListener("drop", stop);
+
+        cleanupRef.current = () => {
+            el.removeEventListener("dragover", onDragOver, true);
+            el.removeEventListener("dragleave", onDragLeave, true);
+            window.removeEventListener("dragend", stop);
+            window.removeEventListener("drop", stop);
+            stop();
+        };
+    }, []);
+
+    // Detach on unmount.
+    useEffect(() => () => {
+        cleanupRef.current?.();
+    }, []);
+
+    return setNode;
+}
+
+export default useDragAutoScroll;

--- a/ui/src/pages/compose/state/files.ts
+++ b/ui/src/pages/compose/state/files.ts
@@ -2,6 +2,16 @@ import {create} from 'zustand'
 import {getContextKey} from "../../../context/tab-context.tsx";
 import {immer} from "zustand/middleware/immer";
 
+// useFileDrag is a transient (non-persisted) flag that is true while a file-tree
+// entry is being dragged. It drives the temporary "drop to root" banner, which
+// is only rendered during a drag so it takes no layout space the rest of the time.
+export const useFileDrag = create<{ dragging: boolean; setDragging: (v: boolean) => void }>(
+    (set) => ({
+        dragging: false,
+        setDragging: (dragging: boolean) => set({dragging}),
+    })
+);
+
 export const useAliasStore = create<{
     alias: string
     setAlias: (alias: string) => void


### PR DESCRIPTION
Moving a file or folder back to the **root** of the tree was hard or impossible with drag-and-drop: a drop only lands at the root when it targets a file already sitting at the root, so an empty root — or a root containing only folders — had no reachable drop target.

## What
- A **"Move to `<root>`" banner** shown **only while an entry is being dragged**, so it takes no space otherwise. It overlays the file-list header (the alias bar), so it never covers a file row and never shifts the list — the latter matters because reflowing the list on `dragstart` moves the dragged row and makes the browser cancel the drag.
- **Auto-scroll** while dragging near the top/bottom edge of the list, so a long tree can be traversed mid-drag (capture-phase listeners, since the rows `stopPropagation` their own `dragover`).
- Correct root-path handling: tree paths are `<alias>/<relpath>`, so a root move keeps the alias prefix (`<alias>/<basename>`).

UI-only; no proto or backend changes.
