### PR TITLE
fix(ui): disable text selection on interface chrome

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -362,7 +362,17 @@ const darkTheme = createTheme({
                 body: {
                     height: '100%',
                     overflow: 'hidden',
+                    // Disable selecting UI chrome text (labels, buttons, table cells…);
+                    // it reads as a native app and avoids accidental highlights.
+                    userSelect: 'none',
+                    WebkitUserSelect: 'none',
                     ...scrollbarStyles,
+                },
+                // …but keep selection where content actually matters: form fields,
+                // the code editor (Monaco), the terminal/logs (xterm) and code blocks.
+                'input, textarea, [contenteditable="true"], pre, code, .monaco-editor, .monaco-editor *, .xterm, .xterm *': {
+                    userSelect: 'text',
+                    WebkitUserSelect: 'text',
                 },
                 '*': scrollbarStyles,
             },


### PR DESCRIPTION
Selecting interface text (labels, buttons, table cells) is easy to trigger by accident and feels unpolished.

Set `user-select: none` on the body and re-enable it only where selecting content is useful: form fields, the Monaco editor, the xterm terminal/logs, and `pre`/`code` blocks.

One-file change in the MUI `CssBaseline` theme overrides.
