### PR TITLE
perf(runtime): cap the Go heap to the container cgroup memory limit

### DIFF
--- a/core/internal/app/app.go
+++ b/core/internal/app/app.go
@@ -25,6 +25,7 @@ import (
 	"github.com/RA341/dockman/internal/viewer"
 	"github.com/RA341/dockman/pkg/argos"
 	"github.com/RA341/dockman/pkg/logger"
+	"github.com/RA341/dockman/pkg/memlimit"
 
 	"github.com/rs/zerolog/log"
 )
@@ -66,6 +67,11 @@ func NewApp(opt ...config.AppOpt) (app *App) {
 	}
 
 	logger.InitConsole(conf.Log.Level, conf.Log.Verbose)
+
+	// Cap the Go heap to the container's cgroup memory limit. The runtime does
+	// not do this on its own, so without it a transient spike inflates RSS and
+	// stays resident. No-op outside a memory-limited container.
+	memlimit.Configure()
 
 	// db and info setup
 	gormDB := database.New(conf.ConfigDir, info.IsDev())

--- a/core/pkg/memlimit/memlimit.go
+++ b/core/pkg/memlimit/memlimit.go
@@ -1,0 +1,107 @@
+// Package memlimit derives the Go runtime soft memory limit (GOMEMLIMIT) from
+// the container's cgroup memory limit.
+//
+// As of Go 1.26 the runtime is cgroup-aware for GOMAXPROCS but still does NOT
+// derive GOMEMLIMIT from cgroups. Left unset, the garbage collector sizes the
+// heap goal at roughly 2x the live heap (GOGC=100) and returns freed pages to
+// the OS only lazily. Any transient spike — exporting/diving an image, replaying
+// a container's log backlog, decoding stats — inflates RSS and then stays
+// resident. In a memory-capped container that reads as steadily high memory and,
+// at worst, an OOM kill.
+//
+// Configure reads the cgroup (v2 first, then v1) memory limit and hands the GC a
+// soft limit at a fraction of it, leaving headroom for memory the Go GC cannot
+// manage (goroutine stacks, the CGO/SQLite allocator, OS overhead). An explicit
+// GOMEMLIMIT in the environment always wins and disables this logic.
+package memlimit
+
+import (
+	"os"
+	"runtime/debug"
+	"strconv"
+	"strings"
+
+	"github.com/dustin/go-humanize"
+	"github.com/rs/zerolog/log"
+)
+
+// defaultRatio is the fraction of the detected cgroup limit handed to the GC as
+// its soft limit; the remainder is headroom for off-heap / CGO / stack memory.
+const defaultRatio = 0.9
+
+const (
+	// cgroup v2 memory limit; the file holds "max" when unlimited.
+	cgroupV2Max = "/sys/fs/cgroup/memory.max"
+	// cgroup v1 memory limit.
+	cgroupV1Max = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+)
+
+// unlimitedThreshold guards against cgroup v1's "no limit" sentinel, which is a
+// page-aligned near-max int64 (PAGE_COUNTER_MAX). Any value at or above this is
+// treated as unlimited rather than as a real limit.
+const unlimitedThreshold = int64(1) << 62
+
+// Configure sets the Go runtime soft memory limit from the cgroup memory limit
+// and returns the applied limit in bytes. It returns 0 (a no-op) when GOMEMLIMIT
+// is already set, when no cgroup limit is found, or when the cgroup is unlimited.
+func Configure() int64 {
+	return configure(defaultRatio, readCgroupLimit)
+}
+
+// configure is the testable core of Configure with an injectable cgroup reader.
+func configure(ratio float64, read func() (int64, bool)) int64 {
+	if v := strings.TrimSpace(os.Getenv("GOMEMLIMIT")); v != "" {
+		// The runtime already parsed and applied GOMEMLIMIT at startup; never
+		// second-guess an explicit operator choice.
+		log.Info().Str("GOMEMLIMIT", v).Msg("respecting GOMEMLIMIT from environment")
+		return 0
+	}
+
+	limit, ok := read()
+	if !ok {
+		log.Debug().Msg("no cgroup memory limit detected; leaving Go soft memory limit unset")
+		return 0
+	}
+
+	soft := int64(float64(limit) * ratio)
+	if soft <= 0 {
+		return 0
+	}
+
+	debug.SetMemoryLimit(soft)
+	log.Info().
+		Str("cgroup_limit", humanize.IBytes(uint64(limit))).
+		Str("go_mem_limit", humanize.IBytes(uint64(soft))).
+		Msg("configured Go soft memory limit from cgroup")
+	return soft
+}
+
+// readCgroupLimit returns the cgroup memory limit in bytes, preferring cgroup v2
+// and falling back to v1. ok is false when no finite limit is configured.
+func readCgroupLimit() (int64, bool) {
+	if v, ok := parseLimitFile(cgroupV2Max); ok {
+		return v, true
+	}
+	return parseLimitFile(cgroupV1Max)
+}
+
+// parseLimitFile reads a single-value cgroup limit file and returns the byte
+// limit. ok is false when the file is missing, empty, "max", or an unlimited
+// sentinel.
+func parseLimitFile(path string) (int64, bool) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return 0, false
+	}
+
+	s := strings.TrimSpace(string(raw))
+	if s == "" || s == "max" { // cgroup v2 unlimited
+		return 0, false
+	}
+
+	v, err := strconv.ParseInt(s, 10, 64)
+	if err != nil || v <= 0 || v >= unlimitedThreshold { // cgroup v1 unlimited sentinel
+		return 0, false
+	}
+	return v, true
+}

--- a/core/pkg/memlimit/memlimit_test.go
+++ b/core/pkg/memlimit/memlimit_test.go
@@ -1,0 +1,91 @@
+package memlimit
+
+import (
+	"os"
+	"path/filepath"
+	"runtime/debug"
+	"testing"
+)
+
+func TestParseLimitFile(t *testing.T) {
+	dir := t.TempDir()
+
+	write := func(name, content string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		return p
+	}
+
+	tests := []struct {
+		name    string
+		content string
+		want    int64
+		wantOK  bool
+	}{
+		{"finite", "536870912\n", 536870912, true},
+		{"v2 max", "max\n", 0, false},
+		{"empty", "  \n", 0, false},
+		{"zero", "0", 0, false},
+		{"negative", "-1", 0, false},
+		{"v1 unlimited sentinel", "9223372036854771712", 0, false},
+		{"garbage", "not-a-number", 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseLimitFile(write(tt.name, tt.content))
+			if ok != tt.wantOK || got != tt.want {
+				t.Fatalf("parseLimitFile(%q) = (%d, %v), want (%d, %v)",
+					tt.content, got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+
+	if _, ok := parseLimitFile(filepath.Join(dir, "does-not-exist")); ok {
+		t.Fatalf("parseLimitFile(missing) returned ok=true")
+	}
+}
+
+func TestConfigureAppliesRatio(t *testing.T) {
+	// restore the process-wide limit after the test
+	prev := debug.SetMemoryLimit(-1)
+	defer debug.SetMemoryLimit(prev)
+
+	const cgroupLimit = int64(1000)
+	got := configure(0.9, func() (int64, bool) { return cgroupLimit, true })
+
+	if want := int64(900); got != want {
+		t.Fatalf("configure applied %d, want %d", got, want)
+	}
+	if applied := debug.SetMemoryLimit(-1); applied != 900 {
+		t.Fatalf("runtime soft limit = %d, want 900", applied)
+	}
+}
+
+func TestConfigureNoLimitIsNoop(t *testing.T) {
+	prev := debug.SetMemoryLimit(-1)
+	defer debug.SetMemoryLimit(prev)
+
+	if got := configure(0.9, func() (int64, bool) { return 0, false }); got != 0 {
+		t.Fatalf("configure with no cgroup limit = %d, want 0", got)
+	}
+	if applied := debug.SetMemoryLimit(-1); applied != prev {
+		t.Fatalf("no-op configure changed the soft limit: got %d, want %d", applied, prev)
+	}
+}
+
+func TestConfigureRespectsEnv(t *testing.T) {
+	t.Setenv("GOMEMLIMIT", "512MiB")
+
+	called := false
+	got := configure(0.9, func() (int64, bool) { called = true; return 1 << 30, true })
+
+	if got != 0 {
+		t.Fatalf("configure with GOMEMLIMIT set = %d, want 0", got)
+	}
+	if called {
+		t.Fatalf("configure read the cgroup despite GOMEMLIMIT being set")
+	}
+}


### PR DESCRIPTION
## Problem

As of Go 1.26 the runtime is cgroup-aware for `GOMAXPROCS` but still does **not** derive `GOMEMLIMIT` from cgroups. Left unset, the GC sizes the heap goal at roughly 2× the live heap (`GOGC=100`) and returns freed pages to the OS only lazily. Any transient spike — exporting/diving an image, replaying a container's log backlog, decoding stats — inflates RSS and then stays resident. In a memory-capped container that reads as steadily high memory and, at worst, an OOM kill.

## Change

New `pkg/memlimit`: at startup it reads the cgroup memory limit (v2 `memory.max`, falling back to v1 `memory.limit_in_bytes`) and hands the GC a soft limit at 90% of it via `runtime/debug.SetMemoryLimit`, leaving headroom for memory the Go GC cannot manage (goroutine stacks, the CGO/SQLite allocator, OS overhead).

- An explicit `GOMEMLIMIT` in the environment always wins and disables the logic.
- Outside a memory-limited container (no cgroup limit / "max") it is a no-op — the runtime is left untouched.
- Wired into `NewApp` right after logger init.
- Pure stdlib, **no new dependencies**. Unit tests cover the limit-file parser (finite / `max` / v1 unlimited sentinel / garbage) and the ratio, no-op, and env-override paths.

## Notes

To benefit, run Dockman with a memory limit (`mem_limit` in Compose, `--memory`, or a Kubernetes limit); the GC will then keep RSS under it instead of ignoring it.