### PR TITLE
fix(docker): release streams and unblock leaked goroutines

### DIFF
--- a/core/internal/docker/container/container.go
+++ b/core/internal/docker/container/container.go
@@ -129,6 +129,12 @@ func (s *Service) ContainerExec(ctx context.Context, containerID string, cmd str
 	return resp.HijackedResponse, nil
 }
 
+// defaultLogTail bounds how much history is replayed when a log stream opens.
+// Without a Tail the daemon streams the container's entire json-file backlog
+// before following, a large transient memory spike on every open for a
+// long-lived container.
+const defaultLogTail = "1000"
+
 func (s *Service) ContainerLogs(ctx context.Context, containerID string) (io.ReadCloser, bool, error) {
 	inspect, err := s.Client.ContainerInspect(ctx, containerID, client.ContainerInspectOptions{})
 	if err != nil {
@@ -140,6 +146,7 @@ func (s *Service) ContainerLogs(ctx context.Context, containerID string) (io.Rea
 		ShowStderr: true,
 		Follow:     true,
 		Details:    true,
+		Tail:       defaultLogTail,
 	})
 	if err != nil {
 		return nil, false, fmt.Errorf("unable to get container logs: %w", err)

--- a/core/internal/docker/container/image.go
+++ b/core/internal/docker/container/image.go
@@ -111,6 +111,9 @@ func (s *Service) ImageDive(ctx context.Context, imageId string) (*diveImg.Analy
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract image data %s: %w", imageId, err)
 	}
+	// body streams the whole image tar (can be many GB); it must be closed or
+	// the response body and the daemon-side export stay pinned in memory.
+	defer fileutil.Close(body)
 
 	parse, err := docker.NewImageArchive(body)
 	if err != nil {

--- a/core/internal/docker/handler_http.go
+++ b/core/internal/docker/handler_http.go
@@ -85,13 +85,16 @@ func (h *HandlerHttp) containerExec(w http.ResponseWriter, r *http.Request) {
 		log.Debug().Msg("Attached to exec process")
 	}
 	defer func(resp *client.HijackedResponse) {
-		// IMPORTANT: use CloseWrite since it stops the internal process
-		// instead of Close which keeps it open
+		// CloseWrite sends EOF to the process stdin so a well-behaved program
+		// exits on its own. Close then tears down the hijacked connection so the
+		// reader goroutine below always unblocks: a process that ignores stdin
+		// EOF would otherwise leave resp.Reader.Read blocked forever, leaking the
+		// goroutine and the hijacked connection.
 		log.Debug().Err(err).Msg("closing con")
-		err = resp.CloseWrite()
-		if err != nil {
-			log.Warn().Err(err).Msg("error occurred while closing connection")
+		if cerr := resp.CloseWrite(); cerr != nil {
+			log.Warn().Err(cerr).Msg("error occurred while closing connection")
 		}
+		resp.Close()
 	}(&resp)
 
 	wsu.WInf(ws, "Connected to Container")
@@ -169,14 +172,20 @@ func (h *HandlerHttp) containerLogs(w http.ResponseWriter, r *http.Request) {
 
 	writer := wsu.NewWsWriter(ws)
 	go func() {
+		var copyErr error
 		if tty {
 			// tty streams dont need docker demultiplexing
-			_, err = io.Copy(writer, logsReader)
+			_, copyErr = io.Copy(writer, logsReader)
 		} else {
 			// docker multiplexed stream
-			_, err = stdcopy.StdCopy(writer, writer, logsReader)
+			_, copyErr = stdcopy.StdCopy(writer, writer, logsReader)
 		}
-		log.Debug().Err(err).Str("cont", contId).Msg("closing logs writer")
+		log.Debug().Err(copyErr).Str("cont", contId).Msg("closing logs writer")
+		// The log stream can end before the client disconnects (e.g. the
+		// container stops). Close the socket so the ws.ReadMessage loop below
+		// unblocks; otherwise this handler goroutine leaks, pinning the socket
+		// buffers and the moby follow connection until the browser tab closes.
+		_ = ws.Close()
 	}()
 
 	for {

--- a/core/internal/viewer/service.go
+++ b/core/internal/viewer/service.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/RA341/dockman/internal/docker"
 	"github.com/RA341/dockman/internal/info"
+	"github.com/RA341/dockman/pkg/fileutil"
 	"github.com/RA341/dockman/pkg/syncmap"
 	"github.com/google/uuid"
 	"github.com/moby/moby/api/types/container"
@@ -112,6 +113,8 @@ func (s *Service) StartSession(ctx context.Context, relPath string, alias string
 	if err != nil {
 		return "", nil, err
 	}
+	// close the pull-progress stream so its response body/connection is released
+	defer fileutil.Close(progress)
 
 	err = progress.Wait(context.Background())
 	if err != nil {


### PR DESCRIPTION
Several moby streaming paths held memory longer than necessary. Individually small, they accumulate into high RSS over a container's lifetime.

## Fixes

- **`ImageDive`** — the `ImageSave` reader (the whole image tar, up to several GB) was never closed, pinning the response body and the daemon-side export until GC. Now closed with `defer`.
- **`containerLogs` websocket** — when the log stream ended before the client disconnected (e.g. the container stopped), the copy goroutine exited but the handler stayed blocked on `ws.ReadMessage` forever, leaking the socket buffers and the moby follow connection until the browser tab closed. The socket is now closed when the copy finishes so the read loop unblocks; a local error variable also removes a data race on the shared `err`.
- **`containerExec` websocket** — the reader goroutine could block on `resp.Reader.Read` forever if the exec'd process ignored the stdin EOF sent by `CloseWrite`. Teardown now also `Close()`s the hijacked connection so the reader always unblocks.
- **`ContainerLogs`** — default `Tail` to the last 1000 lines so opening logs no longer replays the entire json-file backlog, a large transient spike for long-lived containers.
- **`viewer.StartSession`** — close the `ImagePull` progress stream.

No API or behavioural change beyond the bounded log tail.