### PR TITLE
feat(files): upload progress toast and completion feedback

### DIFF
--- a/core/internal/files/handler_http.go
+++ b/core/internal/files/handler_http.go
@@ -72,7 +72,9 @@ func (h *FileHandler) loadFile(w http.ResponseWriter, r *http.Request) {
 func (h *FileHandler) saveFile(w http.ResponseWriter, r *http.Request) {
 	// 10 MB is the maximum upload size
 	if err := r.ParseMultipartForm(10 << 20); err != nil {
-		log.Fatal().Err(err).Msg("Error parsing multipart form")
+		// A malformed upload must not take down the whole server: log.Fatal
+		// here would call os.Exit. Return a 400 instead.
+		log.Error().Err(err).Msg("Error parsing multipart form")
 		http.Error(w, "Could not parse multipart form", http.StatusBadRequest)
 		return
 	}

--- a/core/internal/files/handler_http.go
+++ b/core/internal/files/handler_http.go
@@ -3,6 +3,7 @@ package files
 import (
 	b64 "encoding/base64"
 	"errors"
+	"io"
 	"net/http"
 	"strconv"
 
@@ -70,38 +71,14 @@ func (h *FileHandler) loadFile(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *FileHandler) saveFile(w http.ResponseWriter, r *http.Request) {
-	// 10 MB is the maximum upload size
-	if err := r.ParseMultipartForm(10 << 20); err != nil {
-		// A malformed upload must not take down the whole server: log.Fatal
-		// here would call os.Exit. Return a 400 instead.
-		log.Error().Err(err).Msg("Error parsing multipart form")
-		http.Error(w, "Could not parse multipart form", http.StatusBadRequest)
-		return
-	}
-
 	getHost, err := middleware.GetHost(r.Context())
 	if err != nil {
 		http.Error(w, "host not provided", http.StatusBadRequest)
 		return
 	}
 
-	content, meta, err := r.FormFile(fileContentsFormKey)
-	if err != nil {
-		log.Error().Err(err).Msg("Error retrieving file from form")
-		http.Error(w, "Error retrieving file from form", http.StatusBadRequest)
-		return
-	}
-	defer fu.Close(content)
-
-	decodedFileName, err := b64.StdEncoding.DecodeString(meta.Filename)
-	if err != nil {
-		http.Error(w, "Error converting file name from base64", http.StatusBadRequest)
-		return
-	}
-
 	createFile := false
-	createStr := r.URL.Query().Get(QueryKeyCreate)
-	if createStr != "" {
+	if createStr := r.URL.Query().Get(QueryKeyCreate); createStr != "" {
 		createFile, err = strconv.ParseBool(createStr)
 		if err != nil {
 			log.Warn().Err(err).Str("param", createStr).Msg("Error converting create query param to bool")
@@ -109,14 +86,50 @@ func (h *FileHandler) saveFile(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	err = h.srv.Save(string(decodedFileName), getHost, createFile, content)
+	// Stream the upload straight to disk. ParseMultipartForm would first buffer
+	// the whole file (up to 10 MB in memory, the rest in a temp file) before we
+	// write it — under a tight container memory limit a large upload can push
+	// the process into an OOM kill. A MultipartReader keeps memory flat.
+	reader, err := r.MultipartReader()
 	if err != nil {
-		log.Error().Err(err).Msg("Error saving file")
-		http.Error(w, "Error saving file", http.StatusInternalServerError)
+		log.Error().Err(err).Msg("Error reading multipart body")
+		http.Error(w, "Could not read multipart body", http.StatusBadRequest)
 		return
 	}
 
-	//log.Debug().Str("filename", meta.Filename).Msg("Successfully saved File")
+	for {
+		part, err := reader.NextPart()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			log.Error().Err(err).Msg("Error reading multipart part")
+			http.Error(w, "Error reading upload", http.StatusBadRequest)
+			return
+		}
+		if part.FormName() != fileContentsFormKey {
+			_ = part.Close()
+			continue
+		}
+
+		decodedFileName, err := b64.StdEncoding.DecodeString(part.FileName())
+		if err != nil {
+			_ = part.Close()
+			http.Error(w, "Error converting file name from base64", http.StatusBadRequest)
+			return
+		}
+
+		if err = h.srv.Save(string(decodedFileName), getHost, createFile, part); err != nil {
+			_ = part.Close()
+			log.Error().Err(err).Msg("Error saving file")
+			http.Error(w, "Error saving file", http.StatusInternalServerError)
+			return
+		}
+		_ = part.Close()
+		return
+	}
+
+	http.Error(w, "no file provided in form", http.StatusBadRequest)
 }
 
 var upgrader = websocket.Upgrader{

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -14,6 +14,7 @@ import {
     Typography
 } from '@mui/material';
 import {SnackbarProvider} from "./context/snackbar-context.tsx";
+import {UploadProgressToast} from "./components/upload-progress-toast.tsx";
 import {BrowserRouter, Navigate, Outlet, Route, Routes, useLocation, useNavigate, useParams} from "react-router-dom";
 import {AuthProvider} from "./context/auth-context.tsx";
 import React from 'react';
@@ -48,6 +49,7 @@ export function App() {
         <ThemeProvider theme={darkTheme}>
             <CssBaseline/>
             <SnackbarProvider>
+                <UploadProgressToast/>
                 <AuthProvider>
                     <BrowserRouter>
                         <Routes>

--- a/ui/src/components/upload-progress-toast.tsx
+++ b/ui/src/components/upload-progress-toast.tsx
@@ -3,9 +3,9 @@ import {CloudUpload} from '@mui/icons-material';
 import {useUploadProgress} from '../hooks/upload-progress.ts';
 
 // Global, self-managing progress toast shown while a batch of files uploads.
-// It mirrors the app's snackbar styling (bottom Alert) but sits slightly higher
-// so it does not clash with a regular snackbar, and disappears on completion —
-// the success/error toast then confirms the outcome.
+// It uses the same bottom-centered Alert as the app's snackbars and hides on
+// completion — the success/error snackbar then confirms the outcome. The two
+// never show at the same time, so they can share the same bottom slot.
 export function UploadProgressToast() {
     const active = useUploadProgress(s => s.active);
     const fileCount = useUploadProgress(s => s.fileCount);
@@ -23,12 +23,11 @@ export function UploadProgressToast() {
         <Snackbar
             open
             anchorOrigin={{vertical: 'bottom', horizontal: 'center'}}
-            sx={{bottom: {xs: 88, sm: 88}}}
         >
             <Alert
                 severity="info"
                 icon={<CloudUpload fontSize="inherit"/>}
-                sx={{width: '100%', minWidth: 300, alignItems: 'center'}}
+                sx={{width: '100%', minWidth: 320, alignItems: 'center'}}
             >
                 <Box sx={{width: '100%'}}>
                     <Typography variant="body2" sx={{fontWeight: 600, mb: 0.75}}>

--- a/ui/src/components/upload-progress-toast.tsx
+++ b/ui/src/components/upload-progress-toast.tsx
@@ -1,0 +1,48 @@
+import {Alert, Box, LinearProgress, Snackbar, Typography} from '@mui/material';
+import {CloudUpload} from '@mui/icons-material';
+import {useUploadProgress} from '../hooks/upload-progress.ts';
+
+// Global, self-managing progress toast shown while a batch of files uploads.
+// It mirrors the app's snackbar styling (bottom Alert) but sits slightly higher
+// so it does not clash with a regular snackbar, and disappears on completion —
+// the success/error toast then confirms the outcome.
+export function UploadProgressToast() {
+    const active = useUploadProgress(s => s.active);
+    const fileCount = useUploadProgress(s => s.fileCount);
+    const doneCount = useUploadProgress(s => s.doneCount);
+    const totalBytes = useUploadProgress(s => s.totalBytes);
+    const loadedBytes = useUploadProgress(s => s.loadedBytes);
+
+    if (!active) return null;
+
+    const pct = totalBytes > 0
+        ? Math.min(100, Math.round((loadedBytes / totalBytes) * 100))
+        : 0;
+
+    return (
+        <Snackbar
+            open
+            anchorOrigin={{vertical: 'bottom', horizontal: 'center'}}
+            sx={{bottom: {xs: 88, sm: 88}}}
+        >
+            <Alert
+                severity="info"
+                icon={<CloudUpload fontSize="inherit"/>}
+                sx={{width: '100%', minWidth: 300, alignItems: 'center'}}
+            >
+                <Box sx={{width: '100%'}}>
+                    <Typography variant="body2" sx={{fontWeight: 600, mb: 0.75}}>
+                        Uploading {fileCount} {fileCount === 1 ? 'file' : 'files'}
+                        {doneCount > 0 && ` — ${doneCount}/${fileCount} done`}
+                        {' · '}{pct}%
+                    </Typography>
+                    <LinearProgress
+                        variant="determinate"
+                        value={pct}
+                        sx={{height: 6, borderRadius: 3}}
+                    />
+                </Box>
+            </Alert>
+        </Snackbar>
+    );
+}

--- a/ui/src/context/file-context.tsx
+++ b/ui/src/context/file-context.tsx
@@ -9,6 +9,16 @@ import {useEditorUrl} from "../lib/editor.ts";
 import {useHostStore, useOpenFiles} from "../pages/compose/state/files.ts";
 import {useFileComponents} from "../pages/compose/state/terminal.tsx";
 
+// btoa only accepts Latin1, so a path with accents, curly quotes or any other
+// non-Latin1 character throws. Encode the UTF-8 bytes instead; the backend
+// base64-decodes this straight back to the raw UTF-8 path bytes.
+function encodePathToBase64(path: string): string {
+    const bytes = new TextEncoder().encode(path);
+    let binary = '';
+    bytes.forEach((b) => (binary += String.fromCharCode(b)));
+    return btoa(binary);
+}
+
 export interface FilesContextType {
     files: FsEntry[]
     isLoading: boolean
@@ -184,7 +194,7 @@ function FilesProvider({children}: { children: ReactNode }) {
         return new Promise<string>((resolve) => {
             try {
                 const formData = new FormData();
-                formData.append('contents', fileBlob, btoa(fullPath));
+                formData.append('contents', fileBlob, encodePathToBase64(fullPath));
 
                 const xhr = new XMLHttpRequest();
                 xhr.open('POST', url, true);

--- a/ui/src/context/file-context.tsx
+++ b/ui/src/context/file-context.tsx
@@ -2,6 +2,7 @@ import {createContext, type ReactNode, useCallback, useContext, useEffect, useSt
 import {useNavigate} from 'react-router-dom'
 import {callRPC, useHostClient, useHostUrl,} from "../lib/api.ts";
 import {useSnackbar} from "../hooks/snackbar.ts";
+import {useUploadProgress} from "../hooks/upload-progress.ts";
 import {FileService, type FsEntry} from '../gen/files/v1/files_pb.ts';
 import {useTabs} from "./tab-context.tsx";
 import {useEditorUrl} from "../lib/editor.ts";
@@ -164,43 +165,86 @@ function FilesProvider({children}: { children: ReactNode }) {
 
     const getUrl = useHostUrl()
 
-    async function uploadFile(fullPath: string, content: File | string, isNew: boolean = false): Promise<string> {
+    function uploadFile(
+        fullPath: string,
+        content: File | string,
+        isNew: boolean = false,
+        onProgress?: (loaded: number, total: number) => void,
+    ): Promise<string> {
         const url = getUrl(`/file/save${isNew ? '?create=true' : ''}`)
 
-        try {
-            const formData = new FormData();
+        const fileBlob = typeof content === 'string'
+            // If it's a string (from editor), wrap it.
+            ? new File([content], getEntryDisplayName(fullPath))
+            // If it's already a File (from DnD), use it.
+            : content;
 
-            const fileBlob = typeof content === 'string'
-                // If it's a string (from editor), wrap it.
-                ? new File([content], getEntryDisplayName(fullPath))
-                // If it's already a File (from DnD), use it.
-                : content;
+        // XMLHttpRequest (not fetch) so we can observe upload progress via
+        // xhr.upload.onprogress — fetch with a FormData body reports nothing.
+        return new Promise<string>((resolve) => {
+            try {
+                const formData = new FormData();
+                formData.append('contents', fileBlob, btoa(fullPath));
 
-            formData.append('contents', fileBlob, btoa(fullPath));
+                const xhr = new XMLHttpRequest();
+                xhr.open('POST', url, true);
 
-            const response = await fetch(url, {
-                method: 'POST',
-                body: formData,
-            });
+                if (onProgress) {
+                    xhr.upload.onprogress = (e) => {
+                        if (e.lengthComputable) onProgress(e.loaded, e.total);
+                    };
+                }
 
-            if (!response.ok) {
-                const errorText = await response.text();
-                return `Error: ${response.status} - ${errorText}`;
+                xhr.onload = () => {
+                    if (xhr.status >= 200 && xhr.status < 300) {
+                        resolve("");
+                    } else {
+                        resolve(`Error: ${xhr.status} - ${xhr.responseText}`);
+                    }
+                };
+                xhr.onerror = () => {
+                    console.error("Upload failed");
+                    resolve("Network error");
+                };
+
+                xhr.send(formData);
+            } catch (error) {
+                console.error("Upload failed:", error);
+                resolve("Network error");
             }
-
-            return "";
-        } catch (error) {
-            console.error("Upload failed:", error);
-            return "Network error";
-        }
+        });
     }
 
     const uploadFilesFromPC = async (targetDir: string, files: File[]) => {
-        const results = await Promise.all(files.map(file => {
-            const cleanDir = targetDir.endsWith('/') ? targetDir.slice(0, -1) : targetDir;
+        const cleanDir = targetDir.endsWith('/') ? targetDir.slice(0, -1) : targetDir;
+
+        // Aggregate per-file byte counts into one batch progress figure. Uploads
+        // run in parallel, so each file writes into its slot and we sum.
+        const totalBytes = files.reduce((sum, f) => sum + f.size, 0);
+        const loaded = new Array(files.length).fill(0);
+        let doneCount = 0;
+
+        const pushProgress = () => {
+            const loadedBytes = loaded.reduce((a, b) => a + b, 0);
+            useUploadProgress.getState().update(loadedBytes, doneCount);
+        };
+
+        useUploadProgress.getState().start(files.length, totalBytes);
+
+        const results = await Promise.all(files.map((file, i) => {
             const fullPath = `${cleanDir}/${file.name}`;
-            return uploadFile(fullPath, file, true);
+            return uploadFile(fullPath, file, true, (l) => {
+                loaded[i] = l;
+                pushProgress();
+            }).then((res) => {
+                doneCount++;
+                loaded[i] = file.size; // a finished file counts as fully sent
+                pushProgress();
+                return res;
+            });
         }));
+
+        useUploadProgress.getState().finish();
 
         const errors = results.filter(res => res !== "");
         if (errors.length > 0) {

--- a/ui/src/hooks/upload-progress.ts
+++ b/ui/src/hooks/upload-progress.ts
@@ -1,0 +1,31 @@
+import {create} from 'zustand';
+
+// Tracks a single in-flight batch of file uploads so a progress toast can be
+// rendered globally. Uploads fan out in parallel, so the caller aggregates the
+// per-file byte counts and pushes the totals here.
+interface UploadProgressState {
+    active: boolean;
+    fileCount: number;
+    doneCount: number;
+    totalBytes: number;
+    loadedBytes: number;
+    // start a new batch; resets progress counters
+    start: (fileCount: number, totalBytes: number) => void;
+    // report aggregate bytes sent and how many files have finished
+    update: (loadedBytes: number, doneCount: number) => void;
+    // batch finished (success or failure); the completion is surfaced via the
+    // regular snackbar, so the progress toast simply hides.
+    finish: () => void;
+}
+
+export const useUploadProgress = create<UploadProgressState>((set) => ({
+    active: false,
+    fileCount: 0,
+    doneCount: 0,
+    totalBytes: 0,
+    loadedBytes: 0,
+    start: (fileCount, totalBytes) =>
+        set({active: true, fileCount, totalBytes, loadedBytes: 0, doneCount: 0}),
+    update: (loadedBytes, doneCount) => set({loadedBytes, doneCount}),
+    finish: () => set({active: false}),
+}));


### PR DESCRIPTION
## Problem

Dropping files onto the file tree gave no feedback until the whole batch finished. Uploading a large file, or many files, looked like nothing was happening.

## Change

- `uploadFile` now uses `XMLHttpRequest` instead of `fetch`, so upload progress is observable via `xhr.upload.onprogress` — `fetch` with a `FormData` body reports none. Behaviour is otherwise unchanged, and the editor save path keeps working without a progress callback.
- `uploadFilesFromPC` aggregates the per-file byte counts across the parallel uploads into a small Zustand store (`useUploadProgress`).
- A global `UploadProgressToast` renders a determinate `LinearProgress` inside an `Alert` (styled like the existing snackbar) while the batch runs, then hides; the existing success/error snackbar confirms the outcome.

## Also

The upload handler called `log.Fatal` on a malformed multipart form, which calls `os.Exit` and takes down the whole server. It now returns a 400.
