### PR TITLE
feat(images): show containers using an image in the inspect view

### DIFF
--- a/core/generated/docker/v1/docker.pb.go
+++ b/core/generated/docker/v1/docker.pb.go
@@ -1181,13 +1181,14 @@ func (x *ImageInspectResponse) GetInspect() *ImageInspect {
 }
 
 type ImageInspect struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	Id            string                 `protobuf:"bytes,6,opt,name=id,proto3" json:"id,omitempty"`
-	Size          string                 `protobuf:"bytes,3,opt,name=size,proto3" json:"size,omitempty"`
-	Arch          string                 `protobuf:"bytes,5,opt,name=arch,proto3" json:"arch,omitempty"`
-	CreatedIso    string                 `protobuf:"bytes,4,opt,name=createdIso,proto3" json:"createdIso,omitempty"`
-	Layers        []*ImageLayer          `protobuf:"bytes,2,rep,name=layers,proto3" json:"layers,omitempty"`
+	state         protoimpl.MessageState   `protogen:"open.v1"`
+	Name          string                   `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Id            string                   `protobuf:"bytes,6,opt,name=id,proto3" json:"id,omitempty"`
+	Size          string                   `protobuf:"bytes,3,opt,name=size,proto3" json:"size,omitempty"`
+	Arch          string                   `protobuf:"bytes,5,opt,name=arch,proto3" json:"arch,omitempty"`
+	CreatedIso    string                   `protobuf:"bytes,4,opt,name=createdIso,proto3" json:"createdIso,omitempty"`
+	Layers        []*ImageLayer            `protobuf:"bytes,2,rep,name=layers,proto3" json:"layers,omitempty"`
+	Containers    []*ImageContainerInspect `protobuf:"bytes,7,rep,name=containers,proto3" json:"containers,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1264,6 +1265,13 @@ func (x *ImageInspect) GetLayers() []*ImageLayer {
 	return nil
 }
 
+func (x *ImageInspect) GetContainers() []*ImageContainerInspect {
+	if x != nil {
+		return x.Containers
+	}
+	return nil
+}
+
 type ImageLayer struct {
 	state            protoimpl.MessageState `protogen:"open.v1"`
 	LayerId          string                 `protobuf:"bytes,3,opt,name=LayerId,proto3" json:"LayerId,omitempty"`
@@ -1332,6 +1340,74 @@ func (x *ImageLayer) GetTotalSizeAtLayer() string {
 	return ""
 }
 
+type ImageContainerInspect struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	Name           string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Id             string                 `protobuf:"bytes,2,opt,name=id,proto3" json:"id,omitempty"`
+	State          string                 `protobuf:"bytes,3,opt,name=state,proto3" json:"state,omitempty"`
+	ComposeProject string                 `protobuf:"bytes,4,opt,name=composeProject,proto3" json:"composeProject,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *ImageContainerInspect) Reset() {
+	*x = ImageContainerInspect{}
+	mi := &file_docker_v1_docker_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ImageContainerInspect) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ImageContainerInspect) ProtoMessage() {}
+
+func (x *ImageContainerInspect) ProtoReflect() protoreflect.Message {
+	mi := &file_docker_v1_docker_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ImageContainerInspect.ProtoReflect.Descriptor instead.
+func (*ImageContainerInspect) Descriptor() ([]byte, []int) {
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *ImageContainerInspect) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *ImageContainerInspect) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *ImageContainerInspect) GetState() string {
+	if x != nil {
+		return x.State
+	}
+	return ""
+}
+
+func (x *ImageContainerInspect) GetComposeProject() string {
+	if x != nil {
+		return x.ComposeProject
+	}
+	return ""
+}
+
 type ComposeValidateResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Errs          []string               `protobuf:"bytes,1,rep,name=errs,proto3" json:"errs,omitempty"`
@@ -1341,7 +1417,7 @@ type ComposeValidateResponse struct {
 
 func (x *ComposeValidateResponse) Reset() {
 	*x = ComposeValidateResponse{}
-	mi := &file_docker_v1_docker_proto_msgTypes[19]
+	mi := &file_docker_v1_docker_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1353,7 +1429,7 @@ func (x *ComposeValidateResponse) String() string {
 func (*ComposeValidateResponse) ProtoMessage() {}
 
 func (x *ComposeValidateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[19]
+	mi := &file_docker_v1_docker_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1366,7 +1442,7 @@ func (x *ComposeValidateResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ComposeValidateResponse.ProtoReflect.Descriptor instead.
 func (*ComposeValidateResponse) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{19}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *ComposeValidateResponse) GetErrs() []string {
@@ -1387,7 +1463,7 @@ type ContainerExecCmdInput struct {
 
 func (x *ContainerExecCmdInput) Reset() {
 	*x = ContainerExecCmdInput{}
-	mi := &file_docker_v1_docker_proto_msgTypes[20]
+	mi := &file_docker_v1_docker_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1399,7 +1475,7 @@ func (x *ContainerExecCmdInput) String() string {
 func (*ContainerExecCmdInput) ProtoMessage() {}
 
 func (x *ContainerExecCmdInput) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[20]
+	mi := &file_docker_v1_docker_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1412,7 +1488,7 @@ func (x *ContainerExecCmdInput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ContainerExecCmdInput.ProtoReflect.Descriptor instead.
 func (*ContainerExecCmdInput) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{20}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *ContainerExecCmdInput) GetUserCmd() string {
@@ -1440,7 +1516,7 @@ type ContainerExecRequest struct {
 
 func (x *ContainerExecRequest) Reset() {
 	*x = ContainerExecRequest{}
-	mi := &file_docker_v1_docker_proto_msgTypes[21]
+	mi := &file_docker_v1_docker_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1452,7 +1528,7 @@ func (x *ContainerExecRequest) String() string {
 func (*ContainerExecRequest) ProtoMessage() {}
 
 func (x *ContainerExecRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[21]
+	mi := &file_docker_v1_docker_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1465,7 +1541,7 @@ func (x *ContainerExecRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ContainerExecRequest.ProtoReflect.Descriptor instead.
 func (*ContainerExecRequest) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{21}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *ContainerExecRequest) GetContainerID() string {
@@ -1502,7 +1578,7 @@ type Image struct {
 
 func (x *Image) Reset() {
 	*x = Image{}
-	mi := &file_docker_v1_docker_proto_msgTypes[22]
+	mi := &file_docker_v1_docker_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1514,7 +1590,7 @@ func (x *Image) String() string {
 func (*Image) ProtoMessage() {}
 
 func (x *Image) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[22]
+	mi := &file_docker_v1_docker_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1527,7 +1603,7 @@ func (x *Image) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Image.ProtoReflect.Descriptor instead.
 func (*Image) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{22}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *Image) GetContainers() int64 {
@@ -1618,7 +1694,7 @@ type ManifestSummary struct {
 
 func (x *ManifestSummary) Reset() {
 	*x = ManifestSummary{}
-	mi := &file_docker_v1_docker_proto_msgTypes[23]
+	mi := &file_docker_v1_docker_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1630,7 +1706,7 @@ func (x *ManifestSummary) String() string {
 func (*ManifestSummary) ProtoMessage() {}
 
 func (x *ManifestSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[23]
+	mi := &file_docker_v1_docker_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1643,7 +1719,7 @@ func (x *ManifestSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ManifestSummary.ProtoReflect.Descriptor instead.
 func (*ManifestSummary) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{23}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *ManifestSummary) GetDigest() string {
@@ -1675,7 +1751,7 @@ type ListImagesRequest struct {
 
 func (x *ListImagesRequest) Reset() {
 	*x = ListImagesRequest{}
-	mi := &file_docker_v1_docker_proto_msgTypes[24]
+	mi := &file_docker_v1_docker_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1687,7 +1763,7 @@ func (x *ListImagesRequest) String() string {
 func (*ListImagesRequest) ProtoMessage() {}
 
 func (x *ListImagesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[24]
+	mi := &file_docker_v1_docker_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1700,7 +1776,7 @@ func (x *ListImagesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListImagesRequest.ProtoReflect.Descriptor instead.
 func (*ListImagesRequest) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{24}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{25}
 }
 
 type ListImagesResponse struct {
@@ -1715,7 +1791,7 @@ type ListImagesResponse struct {
 
 func (x *ListImagesResponse) Reset() {
 	*x = ListImagesResponse{}
-	mi := &file_docker_v1_docker_proto_msgTypes[25]
+	mi := &file_docker_v1_docker_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1727,7 +1803,7 @@ func (x *ListImagesResponse) String() string {
 func (*ListImagesResponse) ProtoMessage() {}
 
 func (x *ListImagesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[25]
+	mi := &file_docker_v1_docker_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1740,7 +1816,7 @@ func (x *ListImagesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListImagesResponse.ProtoReflect.Descriptor instead.
 func (*ListImagesResponse) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{25}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *ListImagesResponse) GetTotalDiskUsage() int64 {
@@ -1781,7 +1857,7 @@ type RemoveImageRequest struct {
 
 func (x *RemoveImageRequest) Reset() {
 	*x = RemoveImageRequest{}
-	mi := &file_docker_v1_docker_proto_msgTypes[26]
+	mi := &file_docker_v1_docker_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1793,7 +1869,7 @@ func (x *RemoveImageRequest) String() string {
 func (*RemoveImageRequest) ProtoMessage() {}
 
 func (x *RemoveImageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[26]
+	mi := &file_docker_v1_docker_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1806,7 +1882,7 @@ func (x *RemoveImageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveImageRequest.ProtoReflect.Descriptor instead.
 func (*RemoveImageRequest) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{26}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *RemoveImageRequest) GetHost() string {
@@ -1831,7 +1907,7 @@ type RemoveImageResponse struct {
 
 func (x *RemoveImageResponse) Reset() {
 	*x = RemoveImageResponse{}
-	mi := &file_docker_v1_docker_proto_msgTypes[27]
+	mi := &file_docker_v1_docker_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1843,7 +1919,7 @@ func (x *RemoveImageResponse) String() string {
 func (*RemoveImageResponse) ProtoMessage() {}
 
 func (x *RemoveImageResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[27]
+	mi := &file_docker_v1_docker_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1856,7 +1932,7 @@ func (x *RemoveImageResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveImageResponse.ProtoReflect.Descriptor instead.
 func (*RemoveImageResponse) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{27}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{28}
 }
 
 type ImagePruneResponse struct {
@@ -1869,7 +1945,7 @@ type ImagePruneResponse struct {
 
 func (x *ImagePruneResponse) Reset() {
 	*x = ImagePruneResponse{}
-	mi := &file_docker_v1_docker_proto_msgTypes[28]
+	mi := &file_docker_v1_docker_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1881,7 +1957,7 @@ func (x *ImagePruneResponse) String() string {
 func (*ImagePruneResponse) ProtoMessage() {}
 
 func (x *ImagePruneResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[28]
+	mi := &file_docker_v1_docker_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1894,7 +1970,7 @@ func (x *ImagePruneResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImagePruneResponse.ProtoReflect.Descriptor instead.
 func (*ImagePruneResponse) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{28}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *ImagePruneResponse) GetSpaceReclaimed() uint64 {
@@ -1921,7 +1997,7 @@ type ImagePruneRequest struct {
 
 func (x *ImagePruneRequest) Reset() {
 	*x = ImagePruneRequest{}
-	mi := &file_docker_v1_docker_proto_msgTypes[29]
+	mi := &file_docker_v1_docker_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1933,7 +2009,7 @@ func (x *ImagePruneRequest) String() string {
 func (*ImagePruneRequest) ProtoMessage() {}
 
 func (x *ImagePruneRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[29]
+	mi := &file_docker_v1_docker_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1946,7 +2022,7 @@ func (x *ImagePruneRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImagePruneRequest.ProtoReflect.Descriptor instead.
 func (*ImagePruneRequest) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{29}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *ImagePruneRequest) GetHost() string {
@@ -1973,7 +2049,7 @@ type ImagesDeleted struct {
 
 func (x *ImagesDeleted) Reset() {
 	*x = ImagesDeleted{}
-	mi := &file_docker_v1_docker_proto_msgTypes[30]
+	mi := &file_docker_v1_docker_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1985,7 +2061,7 @@ func (x *ImagesDeleted) String() string {
 func (*ImagesDeleted) ProtoMessage() {}
 
 func (x *ImagesDeleted) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[30]
+	mi := &file_docker_v1_docker_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1998,7 +2074,7 @@ func (x *ImagesDeleted) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImagesDeleted.ProtoReflect.Descriptor instead.
 func (*ImagesDeleted) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{30}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *ImagesDeleted) GetDeleted() string {
@@ -2032,7 +2108,7 @@ type Volume struct {
 
 func (x *Volume) Reset() {
 	*x = Volume{}
-	mi := &file_docker_v1_docker_proto_msgTypes[31]
+	mi := &file_docker_v1_docker_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2044,7 +2120,7 @@ func (x *Volume) String() string {
 func (*Volume) ProtoMessage() {}
 
 func (x *Volume) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[31]
+	mi := &file_docker_v1_docker_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2057,7 +2133,7 @@ func (x *Volume) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Volume.ProtoReflect.Descriptor instead.
 func (*Volume) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{31}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *Volume) GetName() string {
@@ -2124,7 +2200,7 @@ type ListVolumesRequest struct {
 
 func (x *ListVolumesRequest) Reset() {
 	*x = ListVolumesRequest{}
-	mi := &file_docker_v1_docker_proto_msgTypes[32]
+	mi := &file_docker_v1_docker_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2136,7 +2212,7 @@ func (x *ListVolumesRequest) String() string {
 func (*ListVolumesRequest) ProtoMessage() {}
 
 func (x *ListVolumesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[32]
+	mi := &file_docker_v1_docker_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2149,7 +2225,7 @@ func (x *ListVolumesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVolumesRequest.ProtoReflect.Descriptor instead.
 func (*ListVolumesRequest) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{32}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{33}
 }
 
 type ListVolumesResponse struct {
@@ -2161,7 +2237,7 @@ type ListVolumesResponse struct {
 
 func (x *ListVolumesResponse) Reset() {
 	*x = ListVolumesResponse{}
-	mi := &file_docker_v1_docker_proto_msgTypes[33]
+	mi := &file_docker_v1_docker_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2173,7 +2249,7 @@ func (x *ListVolumesResponse) String() string {
 func (*ListVolumesResponse) ProtoMessage() {}
 
 func (x *ListVolumesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[33]
+	mi := &file_docker_v1_docker_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2186,7 +2262,7 @@ func (x *ListVolumesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVolumesResponse.ProtoReflect.Descriptor instead.
 func (*ListVolumesResponse) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{33}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *ListVolumesResponse) GetVolumes() []*Volume {
@@ -2204,7 +2280,7 @@ type CreateVolumeRequest struct {
 
 func (x *CreateVolumeRequest) Reset() {
 	*x = CreateVolumeRequest{}
-	mi := &file_docker_v1_docker_proto_msgTypes[34]
+	mi := &file_docker_v1_docker_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2216,7 +2292,7 @@ func (x *CreateVolumeRequest) String() string {
 func (*CreateVolumeRequest) ProtoMessage() {}
 
 func (x *CreateVolumeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[34]
+	mi := &file_docker_v1_docker_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2229,7 +2305,7 @@ func (x *CreateVolumeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateVolumeRequest.ProtoReflect.Descriptor instead.
 func (*CreateVolumeRequest) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{34}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{35}
 }
 
 type CreateVolumeResponse struct {
@@ -2240,7 +2316,7 @@ type CreateVolumeResponse struct {
 
 func (x *CreateVolumeResponse) Reset() {
 	*x = CreateVolumeResponse{}
-	mi := &file_docker_v1_docker_proto_msgTypes[35]
+	mi := &file_docker_v1_docker_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2252,7 +2328,7 @@ func (x *CreateVolumeResponse) String() string {
 func (*CreateVolumeResponse) ProtoMessage() {}
 
 func (x *CreateVolumeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[35]
+	mi := &file_docker_v1_docker_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2265,7 +2341,7 @@ func (x *CreateVolumeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateVolumeResponse.ProtoReflect.Descriptor instead.
 func (*CreateVolumeResponse) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{35}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{36}
 }
 
 type DeleteVolumeRequest struct {
@@ -2280,7 +2356,7 @@ type DeleteVolumeRequest struct {
 
 func (x *DeleteVolumeRequest) Reset() {
 	*x = DeleteVolumeRequest{}
-	mi := &file_docker_v1_docker_proto_msgTypes[36]
+	mi := &file_docker_v1_docker_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2292,7 +2368,7 @@ func (x *DeleteVolumeRequest) String() string {
 func (*DeleteVolumeRequest) ProtoMessage() {}
 
 func (x *DeleteVolumeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[36]
+	mi := &file_docker_v1_docker_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2305,7 +2381,7 @@ func (x *DeleteVolumeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteVolumeRequest.ProtoReflect.Descriptor instead.
 func (*DeleteVolumeRequest) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{36}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *DeleteVolumeRequest) GetHost() string {
@@ -2344,7 +2420,7 @@ type DeleteVolumeResponse struct {
 
 func (x *DeleteVolumeResponse) Reset() {
 	*x = DeleteVolumeResponse{}
-	mi := &file_docker_v1_docker_proto_msgTypes[37]
+	mi := &file_docker_v1_docker_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2356,7 +2432,7 @@ func (x *DeleteVolumeResponse) String() string {
 func (*DeleteVolumeResponse) ProtoMessage() {}
 
 func (x *DeleteVolumeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[37]
+	mi := &file_docker_v1_docker_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2369,7 +2445,7 @@ func (x *DeleteVolumeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteVolumeResponse.ProtoReflect.Descriptor instead.
 func (*DeleteVolumeResponse) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{37}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{38}
 }
 
 // Network-related messages
@@ -2393,7 +2469,7 @@ type Network struct {
 
 func (x *Network) Reset() {
 	*x = Network{}
-	mi := &file_docker_v1_docker_proto_msgTypes[38]
+	mi := &file_docker_v1_docker_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2405,7 +2481,7 @@ func (x *Network) String() string {
 func (*Network) ProtoMessage() {}
 
 func (x *Network) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[38]
+	mi := &file_docker_v1_docker_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2418,7 +2494,7 @@ func (x *Network) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Network.ProtoReflect.Descriptor instead.
 func (*Network) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{38}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *Network) GetName() string {
@@ -2513,7 +2589,7 @@ type ListNetworksRequest struct {
 
 func (x *ListNetworksRequest) Reset() {
 	*x = ListNetworksRequest{}
-	mi := &file_docker_v1_docker_proto_msgTypes[39]
+	mi := &file_docker_v1_docker_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2525,7 +2601,7 @@ func (x *ListNetworksRequest) String() string {
 func (*ListNetworksRequest) ProtoMessage() {}
 
 func (x *ListNetworksRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[39]
+	mi := &file_docker_v1_docker_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2538,7 +2614,7 @@ func (x *ListNetworksRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNetworksRequest.ProtoReflect.Descriptor instead.
 func (*ListNetworksRequest) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{39}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{40}
 }
 
 type ListNetworksResponse struct {
@@ -2550,7 +2626,7 @@ type ListNetworksResponse struct {
 
 func (x *ListNetworksResponse) Reset() {
 	*x = ListNetworksResponse{}
-	mi := &file_docker_v1_docker_proto_msgTypes[40]
+	mi := &file_docker_v1_docker_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2562,7 +2638,7 @@ func (x *ListNetworksResponse) String() string {
 func (*ListNetworksResponse) ProtoMessage() {}
 
 func (x *ListNetworksResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[40]
+	mi := &file_docker_v1_docker_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2575,7 +2651,7 @@ func (x *ListNetworksResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNetworksResponse.ProtoReflect.Descriptor instead.
 func (*ListNetworksResponse) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{40}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *ListNetworksResponse) GetNetworks() []*Network {
@@ -2593,7 +2669,7 @@ type CreateNetworkRequest struct {
 
 func (x *CreateNetworkRequest) Reset() {
 	*x = CreateNetworkRequest{}
-	mi := &file_docker_v1_docker_proto_msgTypes[41]
+	mi := &file_docker_v1_docker_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2605,7 +2681,7 @@ func (x *CreateNetworkRequest) String() string {
 func (*CreateNetworkRequest) ProtoMessage() {}
 
 func (x *CreateNetworkRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[41]
+	mi := &file_docker_v1_docker_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2618,7 +2694,7 @@ func (x *CreateNetworkRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateNetworkRequest.ProtoReflect.Descriptor instead.
 func (*CreateNetworkRequest) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{41}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{42}
 }
 
 type CreateNetworkResponse struct {
@@ -2629,7 +2705,7 @@ type CreateNetworkResponse struct {
 
 func (x *CreateNetworkResponse) Reset() {
 	*x = CreateNetworkResponse{}
-	mi := &file_docker_v1_docker_proto_msgTypes[42]
+	mi := &file_docker_v1_docker_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2641,7 +2717,7 @@ func (x *CreateNetworkResponse) String() string {
 func (*CreateNetworkResponse) ProtoMessage() {}
 
 func (x *CreateNetworkResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[42]
+	mi := &file_docker_v1_docker_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2654,7 +2730,7 @@ func (x *CreateNetworkResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateNetworkResponse.ProtoReflect.Descriptor instead.
 func (*CreateNetworkResponse) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{42}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{43}
 }
 
 type DeleteNetworkRequest struct {
@@ -2667,7 +2743,7 @@ type DeleteNetworkRequest struct {
 
 func (x *DeleteNetworkRequest) Reset() {
 	*x = DeleteNetworkRequest{}
-	mi := &file_docker_v1_docker_proto_msgTypes[43]
+	mi := &file_docker_v1_docker_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2679,7 +2755,7 @@ func (x *DeleteNetworkRequest) String() string {
 func (*DeleteNetworkRequest) ProtoMessage() {}
 
 func (x *DeleteNetworkRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[43]
+	mi := &file_docker_v1_docker_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2692,7 +2768,7 @@ func (x *DeleteNetworkRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteNetworkRequest.ProtoReflect.Descriptor instead.
 func (*DeleteNetworkRequest) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{43}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *DeleteNetworkRequest) GetNetworkIds() []string {
@@ -2717,7 +2793,7 @@ type DeleteNetworkResponse struct {
 
 func (x *DeleteNetworkResponse) Reset() {
 	*x = DeleteNetworkResponse{}
-	mi := &file_docker_v1_docker_proto_msgTypes[44]
+	mi := &file_docker_v1_docker_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2729,7 +2805,7 @@ func (x *DeleteNetworkResponse) String() string {
 func (*DeleteNetworkResponse) ProtoMessage() {}
 
 func (x *DeleteNetworkResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[44]
+	mi := &file_docker_v1_docker_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2742,7 +2818,7 @@ func (x *DeleteNetworkResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteNetworkResponse.ProtoReflect.Descriptor instead.
 func (*DeleteNetworkResponse) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{44}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{45}
 }
 
 type ContainerLogsRequest struct {
@@ -2754,7 +2830,7 @@ type ContainerLogsRequest struct {
 
 func (x *ContainerLogsRequest) Reset() {
 	*x = ContainerLogsRequest{}
-	mi := &file_docker_v1_docker_proto_msgTypes[45]
+	mi := &file_docker_v1_docker_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2766,7 +2842,7 @@ func (x *ContainerLogsRequest) String() string {
 func (*ContainerLogsRequest) ProtoMessage() {}
 
 func (x *ContainerLogsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[45]
+	mi := &file_docker_v1_docker_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2779,7 +2855,7 @@ func (x *ContainerLogsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ContainerLogsRequest.ProtoReflect.Descriptor instead.
 func (*ContainerLogsRequest) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{45}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *ContainerLogsRequest) GetContainerID() string {
@@ -2798,7 +2874,7 @@ type LogsMessage struct {
 
 func (x *LogsMessage) Reset() {
 	*x = LogsMessage{}
-	mi := &file_docker_v1_docker_proto_msgTypes[46]
+	mi := &file_docker_v1_docker_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2810,7 +2886,7 @@ func (x *LogsMessage) String() string {
 func (*LogsMessage) ProtoMessage() {}
 
 func (x *LogsMessage) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[46]
+	mi := &file_docker_v1_docker_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2823,7 +2899,7 @@ func (x *LogsMessage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LogsMessage.ProtoReflect.Descriptor instead.
 func (*LogsMessage) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{46}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *LogsMessage) GetMessage() string {
@@ -2843,7 +2919,7 @@ type StatsResponse struct {
 
 func (x *StatsResponse) Reset() {
 	*x = StatsResponse{}
-	mi := &file_docker_v1_docker_proto_msgTypes[47]
+	mi := &file_docker_v1_docker_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2855,7 +2931,7 @@ func (x *StatsResponse) String() string {
 func (*StatsResponse) ProtoMessage() {}
 
 func (x *StatsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[47]
+	mi := &file_docker_v1_docker_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2868,7 +2944,7 @@ func (x *StatsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StatsResponse.ProtoReflect.Descriptor instead.
 func (*StatsResponse) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{47}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *StatsResponse) GetSystem() *SystemInfo {
@@ -2897,7 +2973,7 @@ type StatsRequest struct {
 
 func (x *StatsRequest) Reset() {
 	*x = StatsRequest{}
-	mi := &file_docker_v1_docker_proto_msgTypes[48]
+	mi := &file_docker_v1_docker_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2909,7 +2985,7 @@ func (x *StatsRequest) String() string {
 func (*StatsRequest) ProtoMessage() {}
 
 func (x *StatsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[48]
+	mi := &file_docker_v1_docker_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2922,7 +2998,7 @@ func (x *StatsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StatsRequest.ProtoReflect.Descriptor instead.
 func (*StatsRequest) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{48}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *StatsRequest) GetHost() string {
@@ -2963,7 +3039,7 @@ type SystemInfo struct {
 
 func (x *SystemInfo) Reset() {
 	*x = SystemInfo{}
-	mi := &file_docker_v1_docker_proto_msgTypes[49]
+	mi := &file_docker_v1_docker_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2975,7 +3051,7 @@ func (x *SystemInfo) String() string {
 func (*SystemInfo) ProtoMessage() {}
 
 func (x *SystemInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[49]
+	mi := &file_docker_v1_docker_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2988,7 +3064,7 @@ func (x *SystemInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SystemInfo.ProtoReflect.Descriptor instead.
 func (*SystemInfo) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{49}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *SystemInfo) GetCPU() float64 {
@@ -3015,7 +3091,7 @@ type ListResponse struct {
 
 func (x *ListResponse) Reset() {
 	*x = ListResponse{}
-	mi := &file_docker_v1_docker_proto_msgTypes[50]
+	mi := &file_docker_v1_docker_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3027,7 +3103,7 @@ func (x *ListResponse) String() string {
 func (*ListResponse) ProtoMessage() {}
 
 func (x *ListResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[50]
+	mi := &file_docker_v1_docker_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3040,7 +3116,7 @@ func (x *ListResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListResponse.ProtoReflect.Descriptor instead.
 func (*ListResponse) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{50}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *ListResponse) GetStatusCount() map[string]int32 {
@@ -3079,7 +3155,7 @@ type ContainerList struct {
 
 func (x *ContainerList) Reset() {
 	*x = ContainerList{}
-	mi := &file_docker_v1_docker_proto_msgTypes[51]
+	mi := &file_docker_v1_docker_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3091,7 +3167,7 @@ func (x *ContainerList) String() string {
 func (*ContainerList) ProtoMessage() {}
 
 func (x *ContainerList) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[51]
+	mi := &file_docker_v1_docker_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3104,7 +3180,7 @@ func (x *ContainerList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ContainerList.ProtoReflect.Descriptor instead.
 func (*ContainerList) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{51}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *ContainerList) GetId() string {
@@ -3225,7 +3301,7 @@ type ContainerStats struct {
 
 func (x *ContainerStats) Reset() {
 	*x = ContainerStats{}
-	mi := &file_docker_v1_docker_proto_msgTypes[52]
+	mi := &file_docker_v1_docker_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3237,7 +3313,7 @@ func (x *ContainerStats) String() string {
 func (*ContainerStats) ProtoMessage() {}
 
 func (x *ContainerStats) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[52]
+	mi := &file_docker_v1_docker_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3250,7 +3326,7 @@ func (x *ContainerStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ContainerStats.ProtoReflect.Descriptor instead.
 func (*ContainerStats) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{52}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *ContainerStats) GetId() string {
@@ -3328,7 +3404,7 @@ type Port struct {
 
 func (x *Port) Reset() {
 	*x = Port{}
-	mi := &file_docker_v1_docker_proto_msgTypes[53]
+	mi := &file_docker_v1_docker_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3340,7 +3416,7 @@ func (x *Port) String() string {
 func (*Port) ProtoMessage() {}
 
 func (x *Port) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[53]
+	mi := &file_docker_v1_docker_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3353,7 +3429,7 @@ func (x *Port) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Port.ProtoReflect.Descriptor instead.
 func (*Port) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{53}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *Port) GetPublic() int32 {
@@ -3392,7 +3468,7 @@ type Empty struct {
 
 func (x *Empty) Reset() {
 	*x = Empty{}
-	mi := &file_docker_v1_docker_proto_msgTypes[54]
+	mi := &file_docker_v1_docker_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3404,7 +3480,7 @@ func (x *Empty) String() string {
 func (*Empty) ProtoMessage() {}
 
 func (x *Empty) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[54]
+	mi := &file_docker_v1_docker_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3417,7 +3493,7 @@ func (x *Empty) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Empty.ProtoReflect.Descriptor instead.
 func (*Empty) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{54}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{55}
 }
 
 type ContainerRequest struct {
@@ -3429,7 +3505,7 @@ type ContainerRequest struct {
 
 func (x *ContainerRequest) Reset() {
 	*x = ContainerRequest{}
-	mi := &file_docker_v1_docker_proto_msgTypes[55]
+	mi := &file_docker_v1_docker_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3441,7 +3517,7 @@ func (x *ContainerRequest) String() string {
 func (*ContainerRequest) ProtoMessage() {}
 
 func (x *ContainerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[55]
+	mi := &file_docker_v1_docker_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3454,7 +3530,7 @@ func (x *ContainerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ContainerRequest.ProtoReflect.Descriptor instead.
 func (*ContainerRequest) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{55}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *ContainerRequest) GetContainerIds() []string {
@@ -3474,7 +3550,7 @@ type ComposeFile struct {
 
 func (x *ComposeFile) Reset() {
 	*x = ComposeFile{}
-	mi := &file_docker_v1_docker_proto_msgTypes[56]
+	mi := &file_docker_v1_docker_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3486,7 +3562,7 @@ func (x *ComposeFile) String() string {
 func (*ComposeFile) ProtoMessage() {}
 
 func (x *ComposeFile) ProtoReflect() protoreflect.Message {
-	mi := &file_docker_v1_docker_proto_msgTypes[56]
+	mi := &file_docker_v1_docker_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3499,7 +3575,7 @@ func (x *ComposeFile) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ComposeFile.ProtoReflect.Descriptor instead.
 func (*ComposeFile) Descriptor() ([]byte, []int) {
-	return file_docker_v1_docker_proto_rawDescGZIP(), []int{56}
+	return file_docker_v1_docker_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *ComposeFile) GetFilename() string {
@@ -3607,7 +3683,7 @@ const file_docker_v1_docker_proto_rawDesc = "" +
 	"\x13ImageInspectRequest\x12\x18\n" +
 	"\aimageId\x18\x01 \x01(\tR\aimageId\"I\n" +
 	"\x14ImageInspectResponse\x121\n" +
-	"\ainspect\x18\x01 \x01(\v2\x17.docker.v1.ImageInspectR\ainspect\"\xa9\x01\n" +
+	"\ainspect\x18\x01 \x01(\v2\x17.docker.v1.ImageInspectR\ainspect\"\xeb\x01\n" +
 	"\fImageInspect\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x0e\n" +
 	"\x02id\x18\x06 \x01(\tR\x02id\x12\x12\n" +
@@ -3616,13 +3692,21 @@ const file_docker_v1_docker_proto_rawDesc = "" +
 	"\n" +
 	"createdIso\x18\x04 \x01(\tR\n" +
 	"createdIso\x12-\n" +
-	"\x06layers\x18\x02 \x03(\v2\x15.docker.v1.ImageLayerR\x06layers\"x\n" +
+	"\x06layers\x18\x02 \x03(\v2\x15.docker.v1.ImageLayerR\x06layers\x12@\n" +
+	"\n" +
+	"containers\x18\a \x03(\v2 .docker.v1.ImageContainerInspectR\n" +
+	"containers\"x\n" +
 	"\n" +
 	"ImageLayer\x12\x18\n" +
 	"\aLayerId\x18\x03 \x01(\tR\aLayerId\x12\x10\n" +
 	"\x03cmd\x18\x01 \x01(\tR\x03cmd\x12\x12\n" +
 	"\x04size\x18\x02 \x01(\tR\x04size\x12*\n" +
-	"\x10totalSizeAtLayer\x18\x04 \x01(\tR\x10totalSizeAtLayer\"-\n" +
+	"\x10totalSizeAtLayer\x18\x04 \x01(\tR\x10totalSizeAtLayer\"y\n" +
+	"\x15ImageContainerInspect\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x0e\n" +
+	"\x02id\x18\x02 \x01(\tR\x02id\x12\x14\n" +
+	"\x05state\x18\x03 \x01(\tR\x05state\x12&\n" +
+	"\x0ecomposeProject\x18\x04 \x01(\tR\x0ecomposeProject\"-\n" +
 	"\x17ComposeValidateResponse\x12\x12\n" +
 	"\x04errs\x18\x01 \x03(\tR\x04errs\"S\n" +
 	"\x15ContainerExecCmdInput\x12\x18\n" +
@@ -3855,7 +3939,7 @@ func file_docker_v1_docker_proto_rawDescGZIP() []byte {
 }
 
 var file_docker_v1_docker_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_docker_v1_docker_proto_msgTypes = make([]protoimpl.MessageInfo, 61)
+var file_docker_v1_docker_proto_msgTypes = make([]protoimpl.MessageInfo, 62)
 var file_docker_v1_docker_proto_goTypes = []any{
 	(SORT_FIELD)(0),                   // 0: docker.v1.SORT_FIELD
 	(ORDER)(0),                        // 1: docker.v1.ORDER
@@ -3878,141 +3962,143 @@ var file_docker_v1_docker_proto_goTypes = []any{
 	(*ImageInspectResponse)(nil),      // 18: docker.v1.ImageInspectResponse
 	(*ImageInspect)(nil),              // 19: docker.v1.ImageInspect
 	(*ImageLayer)(nil),                // 20: docker.v1.ImageLayer
-	(*ComposeValidateResponse)(nil),   // 21: docker.v1.ComposeValidateResponse
-	(*ContainerExecCmdInput)(nil),     // 22: docker.v1.ContainerExecCmdInput
-	(*ContainerExecRequest)(nil),      // 23: docker.v1.ContainerExecRequest
-	(*Image)(nil),                     // 24: docker.v1.Image
-	(*ManifestSummary)(nil),           // 25: docker.v1.ManifestSummary
-	(*ListImagesRequest)(nil),         // 26: docker.v1.ListImagesRequest
-	(*ListImagesResponse)(nil),        // 27: docker.v1.ListImagesResponse
-	(*RemoveImageRequest)(nil),        // 28: docker.v1.RemoveImageRequest
-	(*RemoveImageResponse)(nil),       // 29: docker.v1.RemoveImageResponse
-	(*ImagePruneResponse)(nil),        // 30: docker.v1.ImagePruneResponse
-	(*ImagePruneRequest)(nil),         // 31: docker.v1.ImagePruneRequest
-	(*ImagesDeleted)(nil),             // 32: docker.v1.ImagesDeleted
-	(*Volume)(nil),                    // 33: docker.v1.Volume
-	(*ListVolumesRequest)(nil),        // 34: docker.v1.ListVolumesRequest
-	(*ListVolumesResponse)(nil),       // 35: docker.v1.ListVolumesResponse
-	(*CreateVolumeRequest)(nil),       // 36: docker.v1.CreateVolumeRequest
-	(*CreateVolumeResponse)(nil),      // 37: docker.v1.CreateVolumeResponse
-	(*DeleteVolumeRequest)(nil),       // 38: docker.v1.DeleteVolumeRequest
-	(*DeleteVolumeResponse)(nil),      // 39: docker.v1.DeleteVolumeResponse
-	(*Network)(nil),                   // 40: docker.v1.Network
-	(*ListNetworksRequest)(nil),       // 41: docker.v1.ListNetworksRequest
-	(*ListNetworksResponse)(nil),      // 42: docker.v1.ListNetworksResponse
-	(*CreateNetworkRequest)(nil),      // 43: docker.v1.CreateNetworkRequest
-	(*CreateNetworkResponse)(nil),     // 44: docker.v1.CreateNetworkResponse
-	(*DeleteNetworkRequest)(nil),      // 45: docker.v1.DeleteNetworkRequest
-	(*DeleteNetworkResponse)(nil),     // 46: docker.v1.DeleteNetworkResponse
-	(*ContainerLogsRequest)(nil),      // 47: docker.v1.ContainerLogsRequest
-	(*LogsMessage)(nil),               // 48: docker.v1.LogsMessage
-	(*StatsResponse)(nil),             // 49: docker.v1.StatsResponse
-	(*StatsRequest)(nil),              // 50: docker.v1.StatsRequest
-	(*SystemInfo)(nil),                // 51: docker.v1.SystemInfo
-	(*ListResponse)(nil),              // 52: docker.v1.ListResponse
-	(*ContainerList)(nil),             // 53: docker.v1.ContainerList
-	(*ContainerStats)(nil),            // 54: docker.v1.ContainerStats
-	(*Port)(nil),                      // 55: docker.v1.Port
-	(*Empty)(nil),                     // 56: docker.v1.Empty
-	(*ContainerRequest)(nil),          // 57: docker.v1.ContainerRequest
-	(*ComposeFile)(nil),               // 58: docker.v1.ComposeFile
-	nil,                               // 59: docker.v1.ComposeFileStatusResponse.StatusEntry
-	nil,                               // 60: docker.v1.ContainerConfig.LabelsEntry
-	nil,                               // 61: docker.v1.Image.LabelsEntry
-	nil,                               // 62: docker.v1.ListResponse.StatusCountEntry
+	(*ImageContainerInspect)(nil),     // 21: docker.v1.ImageContainerInspect
+	(*ComposeValidateResponse)(nil),   // 22: docker.v1.ComposeValidateResponse
+	(*ContainerExecCmdInput)(nil),     // 23: docker.v1.ContainerExecCmdInput
+	(*ContainerExecRequest)(nil),      // 24: docker.v1.ContainerExecRequest
+	(*Image)(nil),                     // 25: docker.v1.Image
+	(*ManifestSummary)(nil),           // 26: docker.v1.ManifestSummary
+	(*ListImagesRequest)(nil),         // 27: docker.v1.ListImagesRequest
+	(*ListImagesResponse)(nil),        // 28: docker.v1.ListImagesResponse
+	(*RemoveImageRequest)(nil),        // 29: docker.v1.RemoveImageRequest
+	(*RemoveImageResponse)(nil),       // 30: docker.v1.RemoveImageResponse
+	(*ImagePruneResponse)(nil),        // 31: docker.v1.ImagePruneResponse
+	(*ImagePruneRequest)(nil),         // 32: docker.v1.ImagePruneRequest
+	(*ImagesDeleted)(nil),             // 33: docker.v1.ImagesDeleted
+	(*Volume)(nil),                    // 34: docker.v1.Volume
+	(*ListVolumesRequest)(nil),        // 35: docker.v1.ListVolumesRequest
+	(*ListVolumesResponse)(nil),       // 36: docker.v1.ListVolumesResponse
+	(*CreateVolumeRequest)(nil),       // 37: docker.v1.CreateVolumeRequest
+	(*CreateVolumeResponse)(nil),      // 38: docker.v1.CreateVolumeResponse
+	(*DeleteVolumeRequest)(nil),       // 39: docker.v1.DeleteVolumeRequest
+	(*DeleteVolumeResponse)(nil),      // 40: docker.v1.DeleteVolumeResponse
+	(*Network)(nil),                   // 41: docker.v1.Network
+	(*ListNetworksRequest)(nil),       // 42: docker.v1.ListNetworksRequest
+	(*ListNetworksResponse)(nil),      // 43: docker.v1.ListNetworksResponse
+	(*CreateNetworkRequest)(nil),      // 44: docker.v1.CreateNetworkRequest
+	(*CreateNetworkResponse)(nil),     // 45: docker.v1.CreateNetworkResponse
+	(*DeleteNetworkRequest)(nil),      // 46: docker.v1.DeleteNetworkRequest
+	(*DeleteNetworkResponse)(nil),     // 47: docker.v1.DeleteNetworkResponse
+	(*ContainerLogsRequest)(nil),      // 48: docker.v1.ContainerLogsRequest
+	(*LogsMessage)(nil),               // 49: docker.v1.LogsMessage
+	(*StatsResponse)(nil),             // 50: docker.v1.StatsResponse
+	(*StatsRequest)(nil),              // 51: docker.v1.StatsRequest
+	(*SystemInfo)(nil),                // 52: docker.v1.SystemInfo
+	(*ListResponse)(nil),              // 53: docker.v1.ListResponse
+	(*ContainerList)(nil),             // 54: docker.v1.ContainerList
+	(*ContainerStats)(nil),            // 55: docker.v1.ContainerStats
+	(*Port)(nil),                      // 56: docker.v1.Port
+	(*Empty)(nil),                     // 57: docker.v1.Empty
+	(*ContainerRequest)(nil),          // 58: docker.v1.ContainerRequest
+	(*ComposeFile)(nil),               // 59: docker.v1.ComposeFile
+	nil,                               // 60: docker.v1.ComposeFileStatusResponse.StatusEntry
+	nil,                               // 61: docker.v1.ContainerConfig.LabelsEntry
+	nil,                               // 62: docker.v1.Image.LabelsEntry
+	nil,                               // 63: docker.v1.ListResponse.StatusCountEntry
 }
 var file_docker_v1_docker_proto_depIdxs = []int32{
-	59, // 0: docker.v1.ComposeFileStatusResponse.status:type_name -> docker.v1.ComposeFileStatusResponse.StatusEntry
+	60, // 0: docker.v1.ComposeFileStatusResponse.status:type_name -> docker.v1.ComposeFileStatusResponse.StatusEntry
 	8,  // 1: docker.v1.ContainerTopResponse.top:type_name -> docker.v1.Top
 	7,  // 2: docker.v1.Top.proc:type_name -> docker.v1.Process
 	11, // 3: docker.v1.ContainerInspectMessage.mounts:type_name -> docker.v1.ContainerMount
 	10, // 4: docker.v1.ContainerInspectMessage.config:type_name -> docker.v1.ContainerConfig
-	60, // 5: docker.v1.ContainerConfig.Labels:type_name -> docker.v1.ContainerConfig.LabelsEntry
+	61, // 5: docker.v1.ContainerConfig.Labels:type_name -> docker.v1.ContainerConfig.LabelsEntry
 	15, // 6: docker.v1.NetworkInspectResponse.inspect:type_name -> docker.v1.NetworkInspectInfo
-	40, // 7: docker.v1.NetworkInspectInfo.net:type_name -> docker.v1.Network
+	41, // 7: docker.v1.NetworkInspectInfo.net:type_name -> docker.v1.Network
 	16, // 8: docker.v1.NetworkInspectInfo.container:type_name -> docker.v1.NetworkContainerInspect
 	19, // 9: docker.v1.ImageInspectResponse.inspect:type_name -> docker.v1.ImageInspect
 	20, // 10: docker.v1.ImageInspect.layers:type_name -> docker.v1.ImageLayer
-	61, // 11: docker.v1.Image.labels:type_name -> docker.v1.Image.LabelsEntry
-	25, // 12: docker.v1.Image.manifests:type_name -> docker.v1.ManifestSummary
-	24, // 13: docker.v1.ListImagesResponse.images:type_name -> docker.v1.Image
-	32, // 14: docker.v1.ImagePruneResponse.deleted:type_name -> docker.v1.ImagesDeleted
-	33, // 15: docker.v1.ListVolumesResponse.volumes:type_name -> docker.v1.Volume
-	40, // 16: docker.v1.ListNetworksResponse.networks:type_name -> docker.v1.Network
-	51, // 17: docker.v1.StatsResponse.system:type_name -> docker.v1.SystemInfo
-	54, // 18: docker.v1.StatsResponse.containers:type_name -> docker.v1.ContainerStats
-	58, // 19: docker.v1.StatsRequest.file:type_name -> docker.v1.ComposeFile
-	0,  // 20: docker.v1.StatsRequest.sortBy:type_name -> docker.v1.SORT_FIELD
-	1,  // 21: docker.v1.StatsRequest.order:type_name -> docker.v1.ORDER
-	62, // 22: docker.v1.ListResponse.statusCount:type_name -> docker.v1.ListResponse.StatusCountEntry
-	53, // 23: docker.v1.ListResponse.list:type_name -> docker.v1.ContainerList
-	55, // 24: docker.v1.ContainerList.ports:type_name -> docker.v1.Port
-	3,  // 25: docker.v1.ComposeFileStatusResponse.StatusEntry.value:type_name -> docker.v1.Status
-	57, // 26: docker.v1.DockerService.ContainerStart:input_type -> docker.v1.ContainerRequest
-	57, // 27: docker.v1.DockerService.ContainerStop:input_type -> docker.v1.ContainerRequest
-	57, // 28: docker.v1.DockerService.ContainerRemove:input_type -> docker.v1.ContainerRequest
-	57, // 29: docker.v1.DockerService.ContainerRestart:input_type -> docker.v1.ContainerRequest
-	57, // 30: docker.v1.DockerService.ContainerUpdate:input_type -> docker.v1.ContainerRequest
-	5,  // 31: docker.v1.DockerService.ContainerTop:input_type -> docker.v1.ContainerTopRequest
-	12, // 32: docker.v1.DockerService.ContainerList:input_type -> docker.v1.ContainerListRequest
-	50, // 33: docker.v1.DockerService.ContainerStats:input_type -> docker.v1.StatsRequest
-	47, // 34: docker.v1.DockerService.ContainerLogs:input_type -> docker.v1.ContainerLogsRequest
-	47, // 35: docker.v1.DockerService.ContainerInspect:input_type -> docker.v1.ContainerLogsRequest
-	58, // 36: docker.v1.DockerService.ComposeUp:input_type -> docker.v1.ComposeFile
-	58, // 37: docker.v1.DockerService.ComposeDown:input_type -> docker.v1.ComposeFile
-	58, // 38: docker.v1.DockerService.ComposeStart:input_type -> docker.v1.ComposeFile
-	58, // 39: docker.v1.DockerService.ComposeStop:input_type -> docker.v1.ComposeFile
-	58, // 40: docker.v1.DockerService.ComposeRestart:input_type -> docker.v1.ComposeFile
-	58, // 41: docker.v1.DockerService.ComposeUpdate:input_type -> docker.v1.ComposeFile
-	58, // 42: docker.v1.DockerService.ComposeList:input_type -> docker.v1.ComposeFile
-	58, // 43: docker.v1.DockerService.ComposeValidate:input_type -> docker.v1.ComposeFile
-	2,  // 44: docker.v1.DockerService.ComposeFileStatus:input_type -> docker.v1.ComposeFileStatusRequest
-	26, // 45: docker.v1.DockerService.ImageList:input_type -> docker.v1.ListImagesRequest
-	28, // 46: docker.v1.DockerService.ImageRemove:input_type -> docker.v1.RemoveImageRequest
-	31, // 47: docker.v1.DockerService.ImagePruneUnused:input_type -> docker.v1.ImagePruneRequest
-	17, // 48: docker.v1.DockerService.ImageInspect:input_type -> docker.v1.ImageInspectRequest
-	34, // 49: docker.v1.DockerService.VolumeList:input_type -> docker.v1.ListVolumesRequest
-	36, // 50: docker.v1.DockerService.VolumeCreate:input_type -> docker.v1.CreateVolumeRequest
-	38, // 51: docker.v1.DockerService.VolumeDelete:input_type -> docker.v1.DeleteVolumeRequest
-	41, // 52: docker.v1.DockerService.NetworkList:input_type -> docker.v1.ListNetworksRequest
-	43, // 53: docker.v1.DockerService.NetworkCreate:input_type -> docker.v1.CreateNetworkRequest
-	45, // 54: docker.v1.DockerService.NetworkDelete:input_type -> docker.v1.DeleteNetworkRequest
-	13, // 55: docker.v1.DockerService.NetworkInspect:input_type -> docker.v1.NetworkInspectRequest
-	48, // 56: docker.v1.DockerService.ContainerStart:output_type -> docker.v1.LogsMessage
-	48, // 57: docker.v1.DockerService.ContainerStop:output_type -> docker.v1.LogsMessage
-	48, // 58: docker.v1.DockerService.ContainerRemove:output_type -> docker.v1.LogsMessage
-	48, // 59: docker.v1.DockerService.ContainerRestart:output_type -> docker.v1.LogsMessage
-	56, // 60: docker.v1.DockerService.ContainerUpdate:output_type -> docker.v1.Empty
-	6,  // 61: docker.v1.DockerService.ContainerTop:output_type -> docker.v1.ContainerTopResponse
-	52, // 62: docker.v1.DockerService.ContainerList:output_type -> docker.v1.ListResponse
-	49, // 63: docker.v1.DockerService.ContainerStats:output_type -> docker.v1.StatsResponse
-	48, // 64: docker.v1.DockerService.ContainerLogs:output_type -> docker.v1.LogsMessage
-	9,  // 65: docker.v1.DockerService.ContainerInspect:output_type -> docker.v1.ContainerInspectMessage
-	48, // 66: docker.v1.DockerService.ComposeUp:output_type -> docker.v1.LogsMessage
-	48, // 67: docker.v1.DockerService.ComposeDown:output_type -> docker.v1.LogsMessage
-	48, // 68: docker.v1.DockerService.ComposeStart:output_type -> docker.v1.LogsMessage
-	48, // 69: docker.v1.DockerService.ComposeStop:output_type -> docker.v1.LogsMessage
-	48, // 70: docker.v1.DockerService.ComposeRestart:output_type -> docker.v1.LogsMessage
-	48, // 71: docker.v1.DockerService.ComposeUpdate:output_type -> docker.v1.LogsMessage
-	52, // 72: docker.v1.DockerService.ComposeList:output_type -> docker.v1.ListResponse
-	21, // 73: docker.v1.DockerService.ComposeValidate:output_type -> docker.v1.ComposeValidateResponse
-	4,  // 74: docker.v1.DockerService.ComposeFileStatus:output_type -> docker.v1.ComposeFileStatusResponse
-	27, // 75: docker.v1.DockerService.ImageList:output_type -> docker.v1.ListImagesResponse
-	29, // 76: docker.v1.DockerService.ImageRemove:output_type -> docker.v1.RemoveImageResponse
-	30, // 77: docker.v1.DockerService.ImagePruneUnused:output_type -> docker.v1.ImagePruneResponse
-	18, // 78: docker.v1.DockerService.ImageInspect:output_type -> docker.v1.ImageInspectResponse
-	35, // 79: docker.v1.DockerService.VolumeList:output_type -> docker.v1.ListVolumesResponse
-	37, // 80: docker.v1.DockerService.VolumeCreate:output_type -> docker.v1.CreateVolumeResponse
-	39, // 81: docker.v1.DockerService.VolumeDelete:output_type -> docker.v1.DeleteVolumeResponse
-	42, // 82: docker.v1.DockerService.NetworkList:output_type -> docker.v1.ListNetworksResponse
-	44, // 83: docker.v1.DockerService.NetworkCreate:output_type -> docker.v1.CreateNetworkResponse
-	46, // 84: docker.v1.DockerService.NetworkDelete:output_type -> docker.v1.DeleteNetworkResponse
-	14, // 85: docker.v1.DockerService.NetworkInspect:output_type -> docker.v1.NetworkInspectResponse
-	56, // [56:86] is the sub-list for method output_type
-	26, // [26:56] is the sub-list for method input_type
-	26, // [26:26] is the sub-list for extension type_name
-	26, // [26:26] is the sub-list for extension extendee
-	0,  // [0:26] is the sub-list for field type_name
+	21, // 11: docker.v1.ImageInspect.containers:type_name -> docker.v1.ImageContainerInspect
+	62, // 12: docker.v1.Image.labels:type_name -> docker.v1.Image.LabelsEntry
+	26, // 13: docker.v1.Image.manifests:type_name -> docker.v1.ManifestSummary
+	25, // 14: docker.v1.ListImagesResponse.images:type_name -> docker.v1.Image
+	33, // 15: docker.v1.ImagePruneResponse.deleted:type_name -> docker.v1.ImagesDeleted
+	34, // 16: docker.v1.ListVolumesResponse.volumes:type_name -> docker.v1.Volume
+	41, // 17: docker.v1.ListNetworksResponse.networks:type_name -> docker.v1.Network
+	52, // 18: docker.v1.StatsResponse.system:type_name -> docker.v1.SystemInfo
+	55, // 19: docker.v1.StatsResponse.containers:type_name -> docker.v1.ContainerStats
+	59, // 20: docker.v1.StatsRequest.file:type_name -> docker.v1.ComposeFile
+	0,  // 21: docker.v1.StatsRequest.sortBy:type_name -> docker.v1.SORT_FIELD
+	1,  // 22: docker.v1.StatsRequest.order:type_name -> docker.v1.ORDER
+	63, // 23: docker.v1.ListResponse.statusCount:type_name -> docker.v1.ListResponse.StatusCountEntry
+	54, // 24: docker.v1.ListResponse.list:type_name -> docker.v1.ContainerList
+	56, // 25: docker.v1.ContainerList.ports:type_name -> docker.v1.Port
+	3,  // 26: docker.v1.ComposeFileStatusResponse.StatusEntry.value:type_name -> docker.v1.Status
+	58, // 27: docker.v1.DockerService.ContainerStart:input_type -> docker.v1.ContainerRequest
+	58, // 28: docker.v1.DockerService.ContainerStop:input_type -> docker.v1.ContainerRequest
+	58, // 29: docker.v1.DockerService.ContainerRemove:input_type -> docker.v1.ContainerRequest
+	58, // 30: docker.v1.DockerService.ContainerRestart:input_type -> docker.v1.ContainerRequest
+	58, // 31: docker.v1.DockerService.ContainerUpdate:input_type -> docker.v1.ContainerRequest
+	5,  // 32: docker.v1.DockerService.ContainerTop:input_type -> docker.v1.ContainerTopRequest
+	12, // 33: docker.v1.DockerService.ContainerList:input_type -> docker.v1.ContainerListRequest
+	51, // 34: docker.v1.DockerService.ContainerStats:input_type -> docker.v1.StatsRequest
+	48, // 35: docker.v1.DockerService.ContainerLogs:input_type -> docker.v1.ContainerLogsRequest
+	48, // 36: docker.v1.DockerService.ContainerInspect:input_type -> docker.v1.ContainerLogsRequest
+	59, // 37: docker.v1.DockerService.ComposeUp:input_type -> docker.v1.ComposeFile
+	59, // 38: docker.v1.DockerService.ComposeDown:input_type -> docker.v1.ComposeFile
+	59, // 39: docker.v1.DockerService.ComposeStart:input_type -> docker.v1.ComposeFile
+	59, // 40: docker.v1.DockerService.ComposeStop:input_type -> docker.v1.ComposeFile
+	59, // 41: docker.v1.DockerService.ComposeRestart:input_type -> docker.v1.ComposeFile
+	59, // 42: docker.v1.DockerService.ComposeUpdate:input_type -> docker.v1.ComposeFile
+	59, // 43: docker.v1.DockerService.ComposeList:input_type -> docker.v1.ComposeFile
+	59, // 44: docker.v1.DockerService.ComposeValidate:input_type -> docker.v1.ComposeFile
+	2,  // 45: docker.v1.DockerService.ComposeFileStatus:input_type -> docker.v1.ComposeFileStatusRequest
+	27, // 46: docker.v1.DockerService.ImageList:input_type -> docker.v1.ListImagesRequest
+	29, // 47: docker.v1.DockerService.ImageRemove:input_type -> docker.v1.RemoveImageRequest
+	32, // 48: docker.v1.DockerService.ImagePruneUnused:input_type -> docker.v1.ImagePruneRequest
+	17, // 49: docker.v1.DockerService.ImageInspect:input_type -> docker.v1.ImageInspectRequest
+	35, // 50: docker.v1.DockerService.VolumeList:input_type -> docker.v1.ListVolumesRequest
+	37, // 51: docker.v1.DockerService.VolumeCreate:input_type -> docker.v1.CreateVolumeRequest
+	39, // 52: docker.v1.DockerService.VolumeDelete:input_type -> docker.v1.DeleteVolumeRequest
+	42, // 53: docker.v1.DockerService.NetworkList:input_type -> docker.v1.ListNetworksRequest
+	44, // 54: docker.v1.DockerService.NetworkCreate:input_type -> docker.v1.CreateNetworkRequest
+	46, // 55: docker.v1.DockerService.NetworkDelete:input_type -> docker.v1.DeleteNetworkRequest
+	13, // 56: docker.v1.DockerService.NetworkInspect:input_type -> docker.v1.NetworkInspectRequest
+	49, // 57: docker.v1.DockerService.ContainerStart:output_type -> docker.v1.LogsMessage
+	49, // 58: docker.v1.DockerService.ContainerStop:output_type -> docker.v1.LogsMessage
+	49, // 59: docker.v1.DockerService.ContainerRemove:output_type -> docker.v1.LogsMessage
+	49, // 60: docker.v1.DockerService.ContainerRestart:output_type -> docker.v1.LogsMessage
+	57, // 61: docker.v1.DockerService.ContainerUpdate:output_type -> docker.v1.Empty
+	6,  // 62: docker.v1.DockerService.ContainerTop:output_type -> docker.v1.ContainerTopResponse
+	53, // 63: docker.v1.DockerService.ContainerList:output_type -> docker.v1.ListResponse
+	50, // 64: docker.v1.DockerService.ContainerStats:output_type -> docker.v1.StatsResponse
+	49, // 65: docker.v1.DockerService.ContainerLogs:output_type -> docker.v1.LogsMessage
+	9,  // 66: docker.v1.DockerService.ContainerInspect:output_type -> docker.v1.ContainerInspectMessage
+	49, // 67: docker.v1.DockerService.ComposeUp:output_type -> docker.v1.LogsMessage
+	49, // 68: docker.v1.DockerService.ComposeDown:output_type -> docker.v1.LogsMessage
+	49, // 69: docker.v1.DockerService.ComposeStart:output_type -> docker.v1.LogsMessage
+	49, // 70: docker.v1.DockerService.ComposeStop:output_type -> docker.v1.LogsMessage
+	49, // 71: docker.v1.DockerService.ComposeRestart:output_type -> docker.v1.LogsMessage
+	49, // 72: docker.v1.DockerService.ComposeUpdate:output_type -> docker.v1.LogsMessage
+	53, // 73: docker.v1.DockerService.ComposeList:output_type -> docker.v1.ListResponse
+	22, // 74: docker.v1.DockerService.ComposeValidate:output_type -> docker.v1.ComposeValidateResponse
+	4,  // 75: docker.v1.DockerService.ComposeFileStatus:output_type -> docker.v1.ComposeFileStatusResponse
+	28, // 76: docker.v1.DockerService.ImageList:output_type -> docker.v1.ListImagesResponse
+	30, // 77: docker.v1.DockerService.ImageRemove:output_type -> docker.v1.RemoveImageResponse
+	31, // 78: docker.v1.DockerService.ImagePruneUnused:output_type -> docker.v1.ImagePruneResponse
+	18, // 79: docker.v1.DockerService.ImageInspect:output_type -> docker.v1.ImageInspectResponse
+	36, // 80: docker.v1.DockerService.VolumeList:output_type -> docker.v1.ListVolumesResponse
+	38, // 81: docker.v1.DockerService.VolumeCreate:output_type -> docker.v1.CreateVolumeResponse
+	40, // 82: docker.v1.DockerService.VolumeDelete:output_type -> docker.v1.DeleteVolumeResponse
+	43, // 83: docker.v1.DockerService.NetworkList:output_type -> docker.v1.ListNetworksResponse
+	45, // 84: docker.v1.DockerService.NetworkCreate:output_type -> docker.v1.CreateNetworkResponse
+	47, // 85: docker.v1.DockerService.NetworkDelete:output_type -> docker.v1.DeleteNetworkResponse
+	14, // 86: docker.v1.DockerService.NetworkInspect:output_type -> docker.v1.NetworkInspectResponse
+	57, // [57:87] is the sub-list for method output_type
+	27, // [27:57] is the sub-list for method input_type
+	27, // [27:27] is the sub-list for extension type_name
+	27, // [27:27] is the sub-list for extension extendee
+	0,  // [0:27] is the sub-list for field type_name
 }
 
 func init() { file_docker_v1_docker_proto_init() }
@@ -4026,7 +4112,7 @@ func file_docker_v1_docker_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_docker_v1_docker_proto_rawDesc), len(file_docker_v1_docker_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   61,
+			NumMessages:   62,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/core/internal/docker/container/image.go
+++ b/core/internal/docker/container/image.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/RA341/dockman/pkg/fileutil"
+	"github.com/docker/compose/v5/pkg/api"
 	"github.com/moby/moby/api/types/image"
 	"github.com/moby/moby/client"
 	"github.com/rs/zerolog/log"
@@ -41,6 +43,46 @@ func (s *Service) ImageInspect(ctx context.Context, id string) (client.ImageInsp
 	}
 
 	return inspect, hist, nil
+}
+
+// ImageContainer describes one container created from a given image.
+type ImageContainer struct {
+	ID             string
+	Name           string
+	State          string
+	ComposeProject string
+}
+
+// ImageContainers returns every container created from the given image. The
+// image inspect data does not carry this, so it is derived from the container
+// list filtered by the image "ancestor".
+func (s *Service) ImageContainers(ctx context.Context, imageID string) ([]ImageContainer, error) {
+	filters := client.Filters{}
+	filters.Add("ancestor", imageID)
+
+	resp, err := s.Client.ContainerList(ctx, client.ContainerListOptions{
+		All:     true,
+		Filters: filters,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list containers for image %s: %w", imageID, err)
+	}
+
+	out := make([]ImageContainer, 0, len(resp.Items))
+	for _, c := range resp.Items {
+		name := ""
+		if len(c.Names) > 0 {
+			name = strings.TrimPrefix(c.Names[0], "/")
+		}
+		out = append(out, ImageContainer{
+			ID:             c.ID,
+			Name:           name,
+			State:          string(c.State),
+			ComposeProject: c.Labels[api.ProjectLabel],
+		})
+	}
+
+	return out, nil
 }
 
 func (s *Service) ImagePull(ctx context.Context, imageTag string, writer io.Writer) error {

--- a/core/internal/docker/handler_images.go
+++ b/core/internal/docker/handler_images.go
@@ -156,6 +156,20 @@ func (h *Handler) ImageInspect(ctx context.Context, req *connect.Request[v1.Imag
 		name = sd
 	}
 
+	conts, err := dkSrv.Container.ImageContainers(ctx, req.Msg.ImageId)
+	if err != nil {
+		return nil, err
+	}
+	rpcConts := make([]*v1.ImageContainerInspect, 0, len(conts))
+	for _, c := range conts {
+		rpcConts = append(rpcConts, &v1.ImageContainerInspect{
+			Name:           c.Name,
+			Id:             c.ID,
+			State:          c.State,
+			ComposeProject: c.ComposeProject,
+		})
+	}
+
 	var insp = &v1.ImageInspect{
 		Name:       name,
 		Id:         inspect.ID,
@@ -163,6 +177,7 @@ func (h *Handler) ImageInspect(ctx context.Context, req *connect.Request[v1.Imag
 		Size:       humanize.Bytes(uint64(inspect.Size)),
 		CreatedIso: inspect.Created,
 		Layers:     layers,
+		Containers: rpcConts,
 	}
 
 	return connect.NewResponse(&v1.ImageInspectResponse{

--- a/spec/protos/docker/v1/docker.proto
+++ b/spec/protos/docker/v1/docker.proto
@@ -168,6 +168,7 @@ message ImageInspect {
   string arch = 5;
   string createdIso = 4;
   repeated ImageLayer layers = 2;
+  repeated ImageContainerInspect containers = 7;
 }
 
 message ImageLayer {
@@ -175,6 +176,13 @@ message ImageLayer {
   string cmd = 1;
   string size = 2;
   string totalSizeAtLayer = 4;
+}
+
+message ImageContainerInspect {
+  string name = 1;
+  string id = 2;
+  string state = 3;
+  string composeProject = 4;
 }
 
 message ComposeValidateResponse {

--- a/ui/src/gen/docker/v1/docker_pb.ts
+++ b/ui/src/gen/docker/v1/docker_pb.ts
@@ -10,7 +10,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file docker/v1/docker.proto.
  */
 export const file_docker_v1_docker: GenFile = /*@__PURE__*/
-  fileDesc("ChZkb2NrZXIvdjEvZG9ja2VyLnByb3RvEglkb2NrZXIudjEiKQoYQ29tcG9zZUZpbGVTdGF0dXNSZXF1ZXN0Eg0KBWZpbGVzGAEgAygJImYKBlN0YXR1cxISCgpzZXJ2aWNlc1VwGAEgASgFEhQKDHNlcnZpY2VzRG93bhgCIAEoBRIXCg9zZXJ2aWNlc0hlYWx0aHkYAyABKAUSGQoRc2VydmljZXNVbkhlYWx0aHkYBCABKAUinwEKGUNvbXBvc2VGaWxlU3RhdHVzUmVzcG9uc2USQAoGc3RhdHVzGAEgAygLMjAuZG9ja2VyLnYxLkNvbXBvc2VGaWxlU3RhdHVzUmVzcG9uc2UuU3RhdHVzRW50cnkaQAoLU3RhdHVzRW50cnkSCwoDa2V5GAEgASgJEiAKBXZhbHVlGAIgASgLMhEuZG9ja2VyLnYxLlN0YXR1czoCOAEiKgoTQ29udGFpbmVyVG9wUmVxdWVzdBITCgtjb250YWluZXJJZBgBIAEoCSIzChRDb250YWluZXJUb3BSZXNwb25zZRIbCgN0b3AYASABKAsyDi5kb2NrZXIudjEuVG9wIhwKB1Byb2Nlc3MSEQoJUHJvY2Vzc2VzGAEgAygJIjcKA1RvcBIgCgRwcm9jGAEgAygLMhIuZG9ja2VyLnYxLlByb2Nlc3MSDgoGVGl0bGVzGAIgAygJIssBChdDb250YWluZXJJbnNwZWN0TWVzc2FnZRIMCgROYW1lGAEgASgJEgoKAklEGAIgASgJEgwKBFBhdGgYAyABKAkSDwoHQ3JlYXRlZBgHIAEoCRINCgVJbWFnZRgEIAEoCRIRCglIb3N0c1BhdGgYBSABKAkSKQoGbW91bnRzGAYgAygLMhkuZG9ja2VyLnYxLkNvbnRhaW5lck1vdW50EioKBmNvbmZpZxgIIAEoCzIaLmRvY2tlci52MS5Db250YWluZXJDb25maWcirQMKD0NvbnRhaW5lckNvbmZpZxIQCghIb3N0bmFtZRgBIAEoCRISCgpEb21haW5uYW1lGAIgASgJEgwKBFVzZXIYAyABKAkSEwoLQXR0YWNoU3RkaW4YBCABKAgSFAoMQXR0YWNoU3Rkb3V0GAUgASgIEhQKDEF0dGFjaFN0ZGVychgGIAEoCBILCgNUdHkYByABKAgSEQoJT3BlblN0ZGluGAggASgIEhEKCVN0ZGluT25jZRgJIAEoCBITCgtBcmdzRXNjYXBlZBgKIAEoCBINCgVJbWFnZRgLIAEoCRILCgNFbnYYDCADKAkSCwoDQ21kGA0gAygJEg8KB1ZvbHVtZXMYDiADKAkSEgoKV29ya2luZ0RpchgPIAEoCRISCgpFbnRyeXBvaW50GBAgAygJEjYKBkxhYmVscxgRIAMoCzImLmRvY2tlci52MS5Db250YWluZXJDb25maWcuTGFiZWxzRW50cnkSFAoMRXhwb3NlZFBvcnRzGBIgAygJGi0KC0xhYmVsc0VudHJ5EgsKA2tleRgBIAEoCRINCgV2YWx1ZRgCIAEoCToCOAEiewoOQ29udGFpbmVyTW91bnQSDAoEVHlwZRgBIAEoCRIMCgROYW1lGAIgASgJEg4KBlNvdXJjZRgDIAEoCRITCgtEZXN0aW5hdGlvbhgEIAEoCRIOCgZEcml2ZXIYBSABKAkSDAoETW9kZRgGIAEoCRIKCgJSVxgHIAEoCCIWChRDb250YWluZXJMaXN0UmVxdWVzdCIqChVOZXR3b3JrSW5zcGVjdFJlcXVlc3QSEQoJbmV0d29ya0lkGAEgASgJIkgKFk5ldHdvcmtJbnNwZWN0UmVzcG9uc2USLgoHaW5zcGVjdBgBIAEoCzIdLmRvY2tlci52MS5OZXR3b3JrSW5zcGVjdEluZm8ibAoSTmV0d29ya0luc3BlY3RJbmZvEh8KA25ldBgBIAEoCzISLmRvY2tlci52MS5OZXR3b3JrEjUKCWNvbnRhaW5lchgCIAMoCzIiLmRvY2tlci52MS5OZXR3b3JrQ29udGFpbmVySW5zcGVjdCJiChdOZXR3b3JrQ29udGFpbmVySW5zcGVjdBIMCgROYW1lGAEgASgJEhAKCEVuZHBvaW50GAIgASgJEgwKBElQdjQYAyABKAkSDAoESVB2NhgEIAEoCRILCgNNYWMYBSABKAkiJgoTSW1hZ2VJbnNwZWN0UmVxdWVzdBIPCgdpbWFnZUlkGAEgASgJIkAKFEltYWdlSW5zcGVjdFJlc3BvbnNlEigKB2luc3BlY3QYASABKAsyFy5kb2NrZXIudjEuSW1hZ2VJbnNwZWN0In8KDEltYWdlSW5zcGVjdBIMCgRuYW1lGAEgASgJEgoKAmlkGAYgASgJEgwKBHNpemUYAyABKAkSDAoEYXJjaBgFIAEoCRISCgpjcmVhdGVkSXNvGAQgASgJEiUKBmxheWVycxgCIAMoCzIVLmRvY2tlci52MS5JbWFnZUxheWVyIlIKCkltYWdlTGF5ZXISDwoHTGF5ZXJJZBgDIAEoCRILCgNjbWQYASABKAkSDAoEc2l6ZRgCIAEoCRIYChB0b3RhbFNpemVBdExheWVyGAQgASgJIicKF0NvbXBvc2VWYWxpZGF0ZVJlc3BvbnNlEgwKBGVycnMYASADKAkiPQoVQ29udGFpbmVyRXhlY0NtZElucHV0Eg8KB3VzZXJDbWQYASABKAkSEwoLY29udGFpbmVySUQYAiABKAkiPAoUQ29udGFpbmVyRXhlY1JlcXVlc3QSEwoLY29udGFpbmVySUQYASABKAkSDwoHZXhlY0NtZBgCIAMoCSK2AgoFSW1hZ2USEgoKY29udGFpbmVycxgBIAEoAxIPCgdjcmVhdGVkGAIgASgDEgoKAmlkGAMgASgJEiwKBmxhYmVscxgEIAMoCzIcLmRvY2tlci52MS5JbWFnZS5MYWJlbHNFbnRyeRIRCglwYXJlbnRfaWQYBSABKAkSLQoJbWFuaWZlc3RzGAcgAygLMhouZG9ja2VyLnYxLk1hbmlmZXN0U3VtbWFyeRIUCgxyZXBvX2RpZ2VzdHMYCCADKAkSEQoJcmVwb190YWdzGAkgAygJEhMKC3NoYXJlZF9zaXplGAogASgDEgwKBHNpemUYCyABKAMSEQoJdXBkYXRlUmVmGAwgASgJGi0KC0xhYmVsc0VudHJ5EgsKA2tleRgBIAEoCRINCgV2YWx1ZRgCIAEoCToCOAEiQwoPTWFuaWZlc3RTdW1tYXJ5Eg4KBmRpZ2VzdBgBIAEoCRISCgptZWRpYV90eXBlGAIgASgJEgwKBHNpemUYAyABKAMiEwoRTGlzdEltYWdlc1JlcXVlc3QihAEKEkxpc3RJbWFnZXNSZXNwb25zZRIWCg50b3RhbERpc2tVc2FnZRgBIAEoAxIYChB1bnVzZWRJbWFnZUNvdW50GAIgASgDEhoKEnVudGFnZ2VkSW1hZ2VDb3VudBgDIAEoAxIgCgZpbWFnZXMYBCADKAsyEC5kb2NrZXIudjEuSW1hZ2UiNAoSUmVtb3ZlSW1hZ2VSZXF1ZXN0EgwKBGhvc3QYAiABKAkSEAoIaW1hZ2VJZHMYASADKAkiFQoTUmVtb3ZlSW1hZ2VSZXNwb25zZSJXChJJbWFnZVBydW5lUmVzcG9uc2USFgoOU3BhY2VSZWNsYWltZWQYASABKAQSKQoHZGVsZXRlZBgCIAMoCzIYLmRvY2tlci52MS5JbWFnZXNEZWxldGVkIjMKEUltYWdlUHJ1bmVSZXF1ZXN0EgwKBGhvc3QYAiABKAkSEAoIcHJ1bmVBbGwYASABKAgiMgoNSW1hZ2VzRGVsZXRlZBIPCgdEZWxldGVkGAEgASgJEhAKCFVudGFnZ2VkGAIgASgJIqEBCgZWb2x1bWUSDAoEbmFtZRgBIAEoCRITCgtjb250YWluZXJJRBgCIAEoCRIRCgljcmVhdGVkQXQYAyABKAkSEgoKbW91bnRQb2ludBgEIAEoCRIMCgRzaXplGAUgASgDEg4KBmxhYmVscxgGIAEoCRITCgtjb21wb3NlUGF0aBgHIAEoCRIaChJjb21wb3NlUHJvamVjdE5hbWUYCCABKAkiFAoSTGlzdFZvbHVtZXNSZXF1ZXN0IjkKE0xpc3RWb2x1bWVzUmVzcG9uc2USIgoHdm9sdW1lcxgBIAMoCzIRLmRvY2tlci52MS5Wb2x1bWUiFQoTQ3JlYXRlVm9sdW1lUmVxdWVzdCIWChRDcmVhdGVWb2x1bWVSZXNwb25zZSJUChNEZWxldGVWb2x1bWVSZXF1ZXN0EgwKBGhvc3QYBCABKAkSEQoJdm9sdW1lSWRzGAEgAygJEgwKBGFub24YAiABKAgSDgoGdW51c2VkGAMgASgIIhYKFERlbGV0ZVZvbHVtZVJlc3BvbnNlIuMBCgdOZXR3b3JrEgwKBG5hbWUYASABKAkSCgoCaWQYAiABKAkSDgoGc3VibmV0GAMgASgJEg0KBXNjb3BlGAQgASgJEg4KBmRyaXZlchgFIAEoCRITCgtlbmFibGVfaXB2NBgGIAEoCBITCgtlbmFibGVfaXB2NhgHIAEoCBIQCghpbnRlcm5hbBgJIAEoCBISCgphdHRhY2hhYmxlGAogASgIEhEKCWNyZWF0ZWRBdBgLIAEoCRIWCg5jb21wb3NlUHJvamVjdBgMIAEoCRIUCgxjb250YWluZXJJZHMYDSADKAkiFQoTTGlzdE5ldHdvcmtzUmVxdWVzdCI8ChRMaXN0TmV0d29ya3NSZXNwb25zZRIkCghuZXR3b3JrcxgBIAMoCzISLmRvY2tlci52MS5OZXR3b3JrIhYKFENyZWF0ZU5ldHdvcmtSZXF1ZXN0IhcKFUNyZWF0ZU5ldHdvcmtSZXNwb25zZSI5ChREZWxldGVOZXR3b3JrUmVxdWVzdBISCgpuZXR3b3JrSWRzGAMgAygJEg0KBXBydW5lGAIgASgIIhcKFURlbGV0ZU5ldHdvcmtSZXNwb25zZSIrChRDb250YWluZXJMb2dzUmVxdWVzdBITCgtjb250YWluZXJJRBgBIAEoCSIeCgtMb2dzTWVzc2FnZRIPCgdtZXNzYWdlGAEgASgJImUKDVN0YXRzUmVzcG9uc2USJQoGc3lzdGVtGAEgASgLMhUuZG9ja2VyLnYxLlN5c3RlbUluZm8SLQoKY29udGFpbmVycxgCIAMoCzIZLmRvY2tlci52MS5Db250YWluZXJTdGF0cyKKAQoMU3RhdHNSZXF1ZXN0EgwKBGhvc3QYBCABKAkSJAoEZmlsZRgBIAEoCzIWLmRvY2tlci52MS5Db21wb3NlRmlsZRIlCgZzb3J0QnkYAiABKA4yFS5kb2NrZXIudjEuU09SVF9GSUVMRBIfCgVvcmRlchgDIAEoDjIQLmRvY2tlci52MS5PUkRFUiItCgpTeXN0ZW1JbmZvEgsKA0NQVRgBIAEoARISCgptZW1JbkJ5dGVzGAIgASgEIqkBCgxMaXN0UmVzcG9uc2USPQoLc3RhdHVzQ291bnQYASADKAsyKC5kb2NrZXIudjEuTGlzdFJlc3BvbnNlLlN0YXR1c0NvdW50RW50cnkSJgoEbGlzdBgCIAMoCzIYLmRvY2tlci52MS5Db250YWluZXJMaXN0GjIKEFN0YXR1c0NvdW50RW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgFOgI4ASKGAgoNQ29udGFpbmVyTGlzdBIKCgJpZBgBIAEoCRIPCgdpbWFnZUlEGAIgASgJEhEKCWltYWdlTmFtZRgDIAEoCRINCgVzdGF0ZRgEIAEoCRIOCgZoZWFsdGgYDSABKAkSDAoEbmFtZRgFIAEoCRIPCgdjcmVhdGVkGAYgASgJEh4KBXBvcnRzGAcgAygLMg8uZG9ja2VyLnYxLlBvcnQSEwoLc2VydmljZU5hbWUYCCABKAkSEwoLc2VydmljZVBhdGgYCSABKAkSEQoJc3RhY2tOYW1lGAogASgJEhcKD3VwZGF0ZUF2YWlsYWJsZRgLIAEoCRIRCglJUEFkZHJlc3MYDCADKAkiugEKDkNvbnRhaW5lclN0YXRzEgoKAmlkGAEgASgJEgwKBG5hbWUYAiABKAkSEQoJY3B1X3VzYWdlGAMgASgBEhQKDG1lbW9yeV91c2FnZRgEIAEoBBIUCgxtZW1vcnlfbGltaXQYBSABKAQSEgoKbmV0d29ya19yeBgGIAEoBBISCgpuZXR3b3JrX3R4GAcgASgEEhIKCmJsb2NrX3JlYWQYCCABKAQSEwoLYmxvY2tfd3JpdGUYCSABKAQiQwoEUG9ydBIOCgZwdWJsaWMYASABKAUSDwoHcHJpdmF0ZRgCIAEoBRIMCgRob3N0GAMgASgJEgwKBHR5cGUYBCABKAkiBwoFRW1wdHkiKAoQQ29udGFpbmVyUmVxdWVzdBIUCgxjb250YWluZXJJZHMYASADKAkiOQoLQ29tcG9zZUZpbGUSEAoIZmlsZW5hbWUYASABKAkSGAoQc2VsZWN0ZWRTZXJ2aWNlcxgDIAMoCSpgCgpTT1JUX0ZJRUxEEggKBE5BTUUQABIHCgNDUFUQARIHCgNNRU0QAhIOCgpORVRXT1JLX1JYEAMSDgoKTkVUV09SS19UWBAEEgoKBkRJU0tfUhAFEgoKBkRJU0tfVxAGKhkKBU9SREVSEgcKA0RTQxAAEgcKA0FTQxABMqISCg1Eb2NrZXJTZXJ2aWNlEkcKDkNvbnRhaW5lclN0YXJ0EhsuZG9ja2VyLnYxLkNvbnRhaW5lclJlcXVlc3QaFi5kb2NrZXIudjEuTG9nc01lc3NhZ2UiABJGCg1Db250YWluZXJTdG9wEhsuZG9ja2VyLnYxLkNvbnRhaW5lclJlcXVlc3QaFi5kb2NrZXIudjEuTG9nc01lc3NhZ2UiABJICg9Db250YWluZXJSZW1vdmUSGy5kb2NrZXIudjEuQ29udGFpbmVyUmVxdWVzdBoWLmRvY2tlci52MS5Mb2dzTWVzc2FnZSIAEkkKEENvbnRhaW5lclJlc3RhcnQSGy5kb2NrZXIudjEuQ29udGFpbmVyUmVxdWVzdBoWLmRvY2tlci52MS5Mb2dzTWVzc2FnZSIAEkIKD0NvbnRhaW5lclVwZGF0ZRIbLmRvY2tlci52MS5Db250YWluZXJSZXF1ZXN0GhAuZG9ja2VyLnYxLkVtcHR5IgASUQoMQ29udGFpbmVyVG9wEh4uZG9ja2VyLnYxLkNvbnRhaW5lclRvcFJlcXVlc3QaHy5kb2NrZXIudjEuQ29udGFpbmVyVG9wUmVzcG9uc2UiABJLCg1Db250YWluZXJMaXN0Eh8uZG9ja2VyLnYxLkNvbnRhaW5lckxpc3RSZXF1ZXN0GhcuZG9ja2VyLnYxLkxpc3RSZXNwb25zZSIAEkUKDkNvbnRhaW5lclN0YXRzEhcuZG9ja2VyLnYxLlN0YXRzUmVxdWVzdBoYLmRvY2tlci52MS5TdGF0c1Jlc3BvbnNlIgASTAoNQ29udGFpbmVyTG9ncxIfLmRvY2tlci52MS5Db250YWluZXJMb2dzUmVxdWVzdBoWLmRvY2tlci52MS5Mb2dzTWVzc2FnZSIAMAESWQoQQ29udGFpbmVySW5zcGVjdBIfLmRvY2tlci52MS5Db250YWluZXJMb2dzUmVxdWVzdBoiLmRvY2tlci52MS5Db250YWluZXJJbnNwZWN0TWVzc2FnZSIAEj8KCUNvbXBvc2VVcBIWLmRvY2tlci52MS5Db21wb3NlRmlsZRoWLmRvY2tlci52MS5Mb2dzTWVzc2FnZSIAMAESQQoLQ29tcG9zZURvd24SFi5kb2NrZXIudjEuQ29tcG9zZUZpbGUaFi5kb2NrZXIudjEuTG9nc01lc3NhZ2UiADABEkIKDENvbXBvc2VTdGFydBIWLmRvY2tlci52MS5Db21wb3NlRmlsZRoWLmRvY2tlci52MS5Mb2dzTWVzc2FnZSIAMAESQQoLQ29tcG9zZVN0b3ASFi5kb2NrZXIudjEuQ29tcG9zZUZpbGUaFi5kb2NrZXIudjEuTG9nc01lc3NhZ2UiADABEkQKDkNvbXBvc2VSZXN0YXJ0EhYuZG9ja2VyLnYxLkNvbXBvc2VGaWxlGhYuZG9ja2VyLnYxLkxvZ3NNZXNzYWdlIgAwARJDCg1Db21wb3NlVXBkYXRlEhYuZG9ja2VyLnYxLkNvbXBvc2VGaWxlGhYuZG9ja2VyLnYxLkxvZ3NNZXNzYWdlIgAwARJACgtDb21wb3NlTGlzdBIWLmRvY2tlci52MS5Db21wb3NlRmlsZRoXLmRvY2tlci52MS5MaXN0UmVzcG9uc2UiABJPCg9Db21wb3NlVmFsaWRhdGUSFi5kb2NrZXIudjEuQ29tcG9zZUZpbGUaIi5kb2NrZXIudjEuQ29tcG9zZVZhbGlkYXRlUmVzcG9uc2UiABJgChFDb21wb3NlRmlsZVN0YXR1cxIjLmRvY2tlci52MS5Db21wb3NlRmlsZVN0YXR1c1JlcXVlc3QaJC5kb2NrZXIudjEuQ29tcG9zZUZpbGVTdGF0dXNSZXNwb25zZSIAEkoKCUltYWdlTGlzdBIcLmRvY2tlci52MS5MaXN0SW1hZ2VzUmVxdWVzdBodLmRvY2tlci52MS5MaXN0SW1hZ2VzUmVzcG9uc2UiABJOCgtJbWFnZVJlbW92ZRIdLmRvY2tlci52MS5SZW1vdmVJbWFnZVJlcXVlc3QaHi5kb2NrZXIudjEuUmVtb3ZlSW1hZ2VSZXNwb25zZSIAElEKEEltYWdlUHJ1bmVVbnVzZWQSHC5kb2NrZXIudjEuSW1hZ2VQcnVuZVJlcXVlc3QaHS5kb2NrZXIudjEuSW1hZ2VQcnVuZVJlc3BvbnNlIgASUQoMSW1hZ2VJbnNwZWN0Eh4uZG9ja2VyLnYxLkltYWdlSW5zcGVjdFJlcXVlc3QaHy5kb2NrZXIudjEuSW1hZ2VJbnNwZWN0UmVzcG9uc2UiABJNCgpWb2x1bWVMaXN0Eh0uZG9ja2VyLnYxLkxpc3RWb2x1bWVzUmVxdWVzdBoeLmRvY2tlci52MS5MaXN0Vm9sdW1lc1Jlc3BvbnNlIgASUQoMVm9sdW1lQ3JlYXRlEh4uZG9ja2VyLnYxLkNyZWF0ZVZvbHVtZVJlcXVlc3QaHy5kb2NrZXIudjEuQ3JlYXRlVm9sdW1lUmVzcG9uc2UiABJRCgxWb2x1bWVEZWxldGUSHi5kb2NrZXIudjEuRGVsZXRlVm9sdW1lUmVxdWVzdBofLmRvY2tlci52MS5EZWxldGVWb2x1bWVSZXNwb25zZSIAElAKC05ldHdvcmtMaXN0Eh4uZG9ja2VyLnYxLkxpc3ROZXR3b3Jrc1JlcXVlc3QaHy5kb2NrZXIudjEuTGlzdE5ldHdvcmtzUmVzcG9uc2UiABJUCg1OZXR3b3JrQ3JlYXRlEh8uZG9ja2VyLnYxLkNyZWF0ZU5ldHdvcmtSZXF1ZXN0GiAuZG9ja2VyLnYxLkNyZWF0ZU5ldHdvcmtSZXNwb25zZSIAElQKDU5ldHdvcmtEZWxldGUSHy5kb2NrZXIudjEuRGVsZXRlTmV0d29ya1JlcXVlc3QaIC5kb2NrZXIudjEuRGVsZXRlTmV0d29ya1Jlc3BvbnNlIgASVwoOTmV0d29ya0luc3BlY3QSIC5kb2NrZXIudjEuTmV0d29ya0luc3BlY3RSZXF1ZXN0GiEuZG9ja2VyLnYxLk5ldHdvcmtJbnNwZWN0UmVzcG9uc2UiAEKPAQoNY29tLmRvY2tlci52MUILRG9ja2VyUHJvdG9QAVosZ2l0aHViLmNvbS9SQTM0MS9kb2NrbWFuL2dlbmVyYXRlZC9kb2NrZXIvdjGiAgNEWFiqAglEb2NrZXIuVjHKAglEb2NrZXJcVjHiAhVEb2NrZXJcVjFcR1BCTWV0YWRhdGHqAgpEb2NrZXI6OlYxYgZwcm90bzM");
+  fileDesc("ChZkb2NrZXIvdjEvZG9ja2VyLnByb3RvEglkb2NrZXIudjEiKQoYQ29tcG9zZUZpbGVTdGF0dXNSZXF1ZXN0Eg0KBWZpbGVzGAEgAygJImYKBlN0YXR1cxISCgpzZXJ2aWNlc1VwGAEgASgFEhQKDHNlcnZpY2VzRG93bhgCIAEoBRIXCg9zZXJ2aWNlc0hlYWx0aHkYAyABKAUSGQoRc2VydmljZXNVbkhlYWx0aHkYBCABKAUinwEKGUNvbXBvc2VGaWxlU3RhdHVzUmVzcG9uc2USQAoGc3RhdHVzGAEgAygLMjAuZG9ja2VyLnYxLkNvbXBvc2VGaWxlU3RhdHVzUmVzcG9uc2UuU3RhdHVzRW50cnkaQAoLU3RhdHVzRW50cnkSCwoDa2V5GAEgASgJEiAKBXZhbHVlGAIgASgLMhEuZG9ja2VyLnYxLlN0YXR1czoCOAEiKgoTQ29udGFpbmVyVG9wUmVxdWVzdBITCgtjb250YWluZXJJZBgBIAEoCSIzChRDb250YWluZXJUb3BSZXNwb25zZRIbCgN0b3AYASABKAsyDi5kb2NrZXIudjEuVG9wIhwKB1Byb2Nlc3MSEQoJUHJvY2Vzc2VzGAEgAygJIjcKA1RvcBIgCgRwcm9jGAEgAygLMhIuZG9ja2VyLnYxLlByb2Nlc3MSDgoGVGl0bGVzGAIgAygJIssBChdDb250YWluZXJJbnNwZWN0TWVzc2FnZRIMCgROYW1lGAEgASgJEgoKAklEGAIgASgJEgwKBFBhdGgYAyABKAkSDwoHQ3JlYXRlZBgHIAEoCRINCgVJbWFnZRgEIAEoCRIRCglIb3N0c1BhdGgYBSABKAkSKQoGbW91bnRzGAYgAygLMhkuZG9ja2VyLnYxLkNvbnRhaW5lck1vdW50EioKBmNvbmZpZxgIIAEoCzIaLmRvY2tlci52MS5Db250YWluZXJDb25maWcirQMKD0NvbnRhaW5lckNvbmZpZxIQCghIb3N0bmFtZRgBIAEoCRISCgpEb21haW5uYW1lGAIgASgJEgwKBFVzZXIYAyABKAkSEwoLQXR0YWNoU3RkaW4YBCABKAgSFAoMQXR0YWNoU3Rkb3V0GAUgASgIEhQKDEF0dGFjaFN0ZGVychgGIAEoCBILCgNUdHkYByABKAgSEQoJT3BlblN0ZGluGAggASgIEhEKCVN0ZGluT25jZRgJIAEoCBITCgtBcmdzRXNjYXBlZBgKIAEoCBINCgVJbWFnZRgLIAEoCRILCgNFbnYYDCADKAkSCwoDQ21kGA0gAygJEg8KB1ZvbHVtZXMYDiADKAkSEgoKV29ya2luZ0RpchgPIAEoCRISCgpFbnRyeXBvaW50GBAgAygJEjYKBkxhYmVscxgRIAMoCzImLmRvY2tlci52MS5Db250YWluZXJDb25maWcuTGFiZWxzRW50cnkSFAoMRXhwb3NlZFBvcnRzGBIgAygJGi0KC0xhYmVsc0VudHJ5EgsKA2tleRgBIAEoCRINCgV2YWx1ZRgCIAEoCToCOAEiewoOQ29udGFpbmVyTW91bnQSDAoEVHlwZRgBIAEoCRIMCgROYW1lGAIgASgJEg4KBlNvdXJjZRgDIAEoCRITCgtEZXN0aW5hdGlvbhgEIAEoCRIOCgZEcml2ZXIYBSABKAkSDAoETW9kZRgGIAEoCRIKCgJSVxgHIAEoCCIWChRDb250YWluZXJMaXN0UmVxdWVzdCIqChVOZXR3b3JrSW5zcGVjdFJlcXVlc3QSEQoJbmV0d29ya0lkGAEgASgJIkgKFk5ldHdvcmtJbnNwZWN0UmVzcG9uc2USLgoHaW5zcGVjdBgBIAEoCzIdLmRvY2tlci52MS5OZXR3b3JrSW5zcGVjdEluZm8ibAoSTmV0d29ya0luc3BlY3RJbmZvEh8KA25ldBgBIAEoCzISLmRvY2tlci52MS5OZXR3b3JrEjUKCWNvbnRhaW5lchgCIAMoCzIiLmRvY2tlci52MS5OZXR3b3JrQ29udGFpbmVySW5zcGVjdCJiChdOZXR3b3JrQ29udGFpbmVySW5zcGVjdBIMCgROYW1lGAEgASgJEhAKCEVuZHBvaW50GAIgASgJEgwKBElQdjQYAyABKAkSDAoESVB2NhgEIAEoCRILCgNNYWMYBSABKAkiJgoTSW1hZ2VJbnNwZWN0UmVxdWVzdBIPCgdpbWFnZUlkGAEgASgJIkAKFEltYWdlSW5zcGVjdFJlc3BvbnNlEigKB2luc3BlY3QYASABKAsyFy5kb2NrZXIudjEuSW1hZ2VJbnNwZWN0IrUBCgxJbWFnZUluc3BlY3QSDAoEbmFtZRgBIAEoCRIKCgJpZBgGIAEoCRIMCgRzaXplGAMgASgJEgwKBGFyY2gYBSABKAkSEgoKY3JlYXRlZElzbxgEIAEoCRIlCgZsYXllcnMYAiADKAsyFS5kb2NrZXIudjEuSW1hZ2VMYXllchI0Cgpjb250YWluZXJzGAcgAygLMiAuZG9ja2VyLnYxLkltYWdlQ29udGFpbmVySW5zcGVjdCJSCgpJbWFnZUxheWVyEg8KB0xheWVySWQYAyABKAkSCwoDY21kGAEgASgJEgwKBHNpemUYAiABKAkSGAoQdG90YWxTaXplQXRMYXllchgEIAEoCSJYChVJbWFnZUNvbnRhaW5lckluc3BlY3QSDAoEbmFtZRgBIAEoCRIKCgJpZBgCIAEoCRINCgVzdGF0ZRgDIAEoCRIWCg5jb21wb3NlUHJvamVjdBgEIAEoCSInChdDb21wb3NlVmFsaWRhdGVSZXNwb25zZRIMCgRlcnJzGAEgAygJIj0KFUNvbnRhaW5lckV4ZWNDbWRJbnB1dBIPCgd1c2VyQ21kGAEgASgJEhMKC2NvbnRhaW5lcklEGAIgASgJIjwKFENvbnRhaW5lckV4ZWNSZXF1ZXN0EhMKC2NvbnRhaW5lcklEGAEgASgJEg8KB2V4ZWNDbWQYAiADKAkitgIKBUltYWdlEhIKCmNvbnRhaW5lcnMYASABKAMSDwoHY3JlYXRlZBgCIAEoAxIKCgJpZBgDIAEoCRIsCgZsYWJlbHMYBCADKAsyHC5kb2NrZXIudjEuSW1hZ2UuTGFiZWxzRW50cnkSEQoJcGFyZW50X2lkGAUgASgJEi0KCW1hbmlmZXN0cxgHIAMoCzIaLmRvY2tlci52MS5NYW5pZmVzdFN1bW1hcnkSFAoMcmVwb19kaWdlc3RzGAggAygJEhEKCXJlcG9fdGFncxgJIAMoCRITCgtzaGFyZWRfc2l6ZRgKIAEoAxIMCgRzaXplGAsgASgDEhEKCXVwZGF0ZVJlZhgMIAEoCRotCgtMYWJlbHNFbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAk6AjgBIkMKD01hbmlmZXN0U3VtbWFyeRIOCgZkaWdlc3QYASABKAkSEgoKbWVkaWFfdHlwZRgCIAEoCRIMCgRzaXplGAMgASgDIhMKEUxpc3RJbWFnZXNSZXF1ZXN0IoQBChJMaXN0SW1hZ2VzUmVzcG9uc2USFgoOdG90YWxEaXNrVXNhZ2UYASABKAMSGAoQdW51c2VkSW1hZ2VDb3VudBgCIAEoAxIaChJ1bnRhZ2dlZEltYWdlQ291bnQYAyABKAMSIAoGaW1hZ2VzGAQgAygLMhAuZG9ja2VyLnYxLkltYWdlIjQKElJlbW92ZUltYWdlUmVxdWVzdBIMCgRob3N0GAIgASgJEhAKCGltYWdlSWRzGAEgAygJIhUKE1JlbW92ZUltYWdlUmVzcG9uc2UiVwoSSW1hZ2VQcnVuZVJlc3BvbnNlEhYKDlNwYWNlUmVjbGFpbWVkGAEgASgEEikKB2RlbGV0ZWQYAiADKAsyGC5kb2NrZXIudjEuSW1hZ2VzRGVsZXRlZCIzChFJbWFnZVBydW5lUmVxdWVzdBIMCgRob3N0GAIgASgJEhAKCHBydW5lQWxsGAEgASgIIjIKDUltYWdlc0RlbGV0ZWQSDwoHRGVsZXRlZBgBIAEoCRIQCghVbnRhZ2dlZBgCIAEoCSKhAQoGVm9sdW1lEgwKBG5hbWUYASABKAkSEwoLY29udGFpbmVySUQYAiABKAkSEQoJY3JlYXRlZEF0GAMgASgJEhIKCm1vdW50UG9pbnQYBCABKAkSDAoEc2l6ZRgFIAEoAxIOCgZsYWJlbHMYBiABKAkSEwoLY29tcG9zZVBhdGgYByABKAkSGgoSY29tcG9zZVByb2plY3ROYW1lGAggASgJIhQKEkxpc3RWb2x1bWVzUmVxdWVzdCI5ChNMaXN0Vm9sdW1lc1Jlc3BvbnNlEiIKB3ZvbHVtZXMYASADKAsyES5kb2NrZXIudjEuVm9sdW1lIhUKE0NyZWF0ZVZvbHVtZVJlcXVlc3QiFgoUQ3JlYXRlVm9sdW1lUmVzcG9uc2UiVAoTRGVsZXRlVm9sdW1lUmVxdWVzdBIMCgRob3N0GAQgASgJEhEKCXZvbHVtZUlkcxgBIAMoCRIMCgRhbm9uGAIgASgIEg4KBnVudXNlZBgDIAEoCCIWChREZWxldGVWb2x1bWVSZXNwb25zZSLjAQoHTmV0d29yaxIMCgRuYW1lGAEgASgJEgoKAmlkGAIgASgJEg4KBnN1Ym5ldBgDIAEoCRINCgVzY29wZRgEIAEoCRIOCgZkcml2ZXIYBSABKAkSEwoLZW5hYmxlX2lwdjQYBiABKAgSEwoLZW5hYmxlX2lwdjYYByABKAgSEAoIaW50ZXJuYWwYCSABKAgSEgoKYXR0YWNoYWJsZRgKIAEoCBIRCgljcmVhdGVkQXQYCyABKAkSFgoOY29tcG9zZVByb2plY3QYDCABKAkSFAoMY29udGFpbmVySWRzGA0gAygJIhUKE0xpc3ROZXR3b3Jrc1JlcXVlc3QiPAoUTGlzdE5ldHdvcmtzUmVzcG9uc2USJAoIbmV0d29ya3MYASADKAsyEi5kb2NrZXIudjEuTmV0d29yayIWChRDcmVhdGVOZXR3b3JrUmVxdWVzdCIXChVDcmVhdGVOZXR3b3JrUmVzcG9uc2UiOQoURGVsZXRlTmV0d29ya1JlcXVlc3QSEgoKbmV0d29ya0lkcxgDIAMoCRINCgVwcnVuZRgCIAEoCCIXChVEZWxldGVOZXR3b3JrUmVzcG9uc2UiKwoUQ29udGFpbmVyTG9nc1JlcXVlc3QSEwoLY29udGFpbmVySUQYASABKAkiHgoLTG9nc01lc3NhZ2USDwoHbWVzc2FnZRgBIAEoCSJlCg1TdGF0c1Jlc3BvbnNlEiUKBnN5c3RlbRgBIAEoCzIVLmRvY2tlci52MS5TeXN0ZW1JbmZvEi0KCmNvbnRhaW5lcnMYAiADKAsyGS5kb2NrZXIudjEuQ29udGFpbmVyU3RhdHMiigEKDFN0YXRzUmVxdWVzdBIMCgRob3N0GAQgASgJEiQKBGZpbGUYASABKAsyFi5kb2NrZXIudjEuQ29tcG9zZUZpbGUSJQoGc29ydEJ5GAIgASgOMhUuZG9ja2VyLnYxLlNPUlRfRklFTEQSHwoFb3JkZXIYAyABKA4yEC5kb2NrZXIudjEuT1JERVIiLQoKU3lzdGVtSW5mbxILCgNDUFUYASABKAESEgoKbWVtSW5CeXRlcxgCIAEoBCKpAQoMTGlzdFJlc3BvbnNlEj0KC3N0YXR1c0NvdW50GAEgAygLMiguZG9ja2VyLnYxLkxpc3RSZXNwb25zZS5TdGF0dXNDb3VudEVudHJ5EiYKBGxpc3QYAiADKAsyGC5kb2NrZXIudjEuQ29udGFpbmVyTGlzdBoyChBTdGF0dXNDb3VudEVudHJ5EgsKA2tleRgBIAEoCRINCgV2YWx1ZRgCIAEoBToCOAEihgIKDUNvbnRhaW5lckxpc3QSCgoCaWQYASABKAkSDwoHaW1hZ2VJRBgCIAEoCRIRCglpbWFnZU5hbWUYAyABKAkSDQoFc3RhdGUYBCABKAkSDgoGaGVhbHRoGA0gASgJEgwKBG5hbWUYBSABKAkSDwoHY3JlYXRlZBgGIAEoCRIeCgVwb3J0cxgHIAMoCzIPLmRvY2tlci52MS5Qb3J0EhMKC3NlcnZpY2VOYW1lGAggASgJEhMKC3NlcnZpY2VQYXRoGAkgASgJEhEKCXN0YWNrTmFtZRgKIAEoCRIXCg91cGRhdGVBdmFpbGFibGUYCyABKAkSEQoJSVBBZGRyZXNzGAwgAygJIroBCg5Db250YWluZXJTdGF0cxIKCgJpZBgBIAEoCRIMCgRuYW1lGAIgASgJEhEKCWNwdV91c2FnZRgDIAEoARIUCgxtZW1vcnlfdXNhZ2UYBCABKAQSFAoMbWVtb3J5X2xpbWl0GAUgASgEEhIKCm5ldHdvcmtfcngYBiABKAQSEgoKbmV0d29ya190eBgHIAEoBBISCgpibG9ja19yZWFkGAggASgEEhMKC2Jsb2NrX3dyaXRlGAkgASgEIkMKBFBvcnQSDgoGcHVibGljGAEgASgFEg8KB3ByaXZhdGUYAiABKAUSDAoEaG9zdBgDIAEoCRIMCgR0eXBlGAQgASgJIgcKBUVtcHR5IigKEENvbnRhaW5lclJlcXVlc3QSFAoMY29udGFpbmVySWRzGAEgAygJIjkKC0NvbXBvc2VGaWxlEhAKCGZpbGVuYW1lGAEgASgJEhgKEHNlbGVjdGVkU2VydmljZXMYAyADKAkqYAoKU09SVF9GSUVMRBIICgROQU1FEAASBwoDQ1BVEAESBwoDTUVNEAISDgoKTkVUV09SS19SWBADEg4KCk5FVFdPUktfVFgQBBIKCgZESVNLX1IQBRIKCgZESVNLX1cQBioZCgVPUkRFUhIHCgNEU0MQABIHCgNBU0MQATKiEgoNRG9ja2VyU2VydmljZRJHCg5Db250YWluZXJTdGFydBIbLmRvY2tlci52MS5Db250YWluZXJSZXF1ZXN0GhYuZG9ja2VyLnYxLkxvZ3NNZXNzYWdlIgASRgoNQ29udGFpbmVyU3RvcBIbLmRvY2tlci52MS5Db250YWluZXJSZXF1ZXN0GhYuZG9ja2VyLnYxLkxvZ3NNZXNzYWdlIgASSAoPQ29udGFpbmVyUmVtb3ZlEhsuZG9ja2VyLnYxLkNvbnRhaW5lclJlcXVlc3QaFi5kb2NrZXIudjEuTG9nc01lc3NhZ2UiABJJChBDb250YWluZXJSZXN0YXJ0EhsuZG9ja2VyLnYxLkNvbnRhaW5lclJlcXVlc3QaFi5kb2NrZXIudjEuTG9nc01lc3NhZ2UiABJCCg9Db250YWluZXJVcGRhdGUSGy5kb2NrZXIudjEuQ29udGFpbmVyUmVxdWVzdBoQLmRvY2tlci52MS5FbXB0eSIAElEKDENvbnRhaW5lclRvcBIeLmRvY2tlci52MS5Db250YWluZXJUb3BSZXF1ZXN0Gh8uZG9ja2VyLnYxLkNvbnRhaW5lclRvcFJlc3BvbnNlIgASSwoNQ29udGFpbmVyTGlzdBIfLmRvY2tlci52MS5Db250YWluZXJMaXN0UmVxdWVzdBoXLmRvY2tlci52MS5MaXN0UmVzcG9uc2UiABJFCg5Db250YWluZXJTdGF0cxIXLmRvY2tlci52MS5TdGF0c1JlcXVlc3QaGC5kb2NrZXIudjEuU3RhdHNSZXNwb25zZSIAEkwKDUNvbnRhaW5lckxvZ3MSHy5kb2NrZXIudjEuQ29udGFpbmVyTG9nc1JlcXVlc3QaFi5kb2NrZXIudjEuTG9nc01lc3NhZ2UiADABElkKEENvbnRhaW5lckluc3BlY3QSHy5kb2NrZXIudjEuQ29udGFpbmVyTG9nc1JlcXVlc3QaIi5kb2NrZXIudjEuQ29udGFpbmVySW5zcGVjdE1lc3NhZ2UiABI/CglDb21wb3NlVXASFi5kb2NrZXIudjEuQ29tcG9zZUZpbGUaFi5kb2NrZXIudjEuTG9nc01lc3NhZ2UiADABEkEKC0NvbXBvc2VEb3duEhYuZG9ja2VyLnYxLkNvbXBvc2VGaWxlGhYuZG9ja2VyLnYxLkxvZ3NNZXNzYWdlIgAwARJCCgxDb21wb3NlU3RhcnQSFi5kb2NrZXIudjEuQ29tcG9zZUZpbGUaFi5kb2NrZXIudjEuTG9nc01lc3NhZ2UiADABEkEKC0NvbXBvc2VTdG9wEhYuZG9ja2VyLnYxLkNvbXBvc2VGaWxlGhYuZG9ja2VyLnYxLkxvZ3NNZXNzYWdlIgAwARJECg5Db21wb3NlUmVzdGFydBIWLmRvY2tlci52MS5Db21wb3NlRmlsZRoWLmRvY2tlci52MS5Mb2dzTWVzc2FnZSIAMAESQwoNQ29tcG9zZVVwZGF0ZRIWLmRvY2tlci52MS5Db21wb3NlRmlsZRoWLmRvY2tlci52MS5Mb2dzTWVzc2FnZSIAMAESQAoLQ29tcG9zZUxpc3QSFi5kb2NrZXIudjEuQ29tcG9zZUZpbGUaFy5kb2NrZXIudjEuTGlzdFJlc3BvbnNlIgASTwoPQ29tcG9zZVZhbGlkYXRlEhYuZG9ja2VyLnYxLkNvbXBvc2VGaWxlGiIuZG9ja2VyLnYxLkNvbXBvc2VWYWxpZGF0ZVJlc3BvbnNlIgASYAoRQ29tcG9zZUZpbGVTdGF0dXMSIy5kb2NrZXIudjEuQ29tcG9zZUZpbGVTdGF0dXNSZXF1ZXN0GiQuZG9ja2VyLnYxLkNvbXBvc2VGaWxlU3RhdHVzUmVzcG9uc2UiABJKCglJbWFnZUxpc3QSHC5kb2NrZXIudjEuTGlzdEltYWdlc1JlcXVlc3QaHS5kb2NrZXIudjEuTGlzdEltYWdlc1Jlc3BvbnNlIgASTgoLSW1hZ2VSZW1vdmUSHS5kb2NrZXIudjEuUmVtb3ZlSW1hZ2VSZXF1ZXN0Gh4uZG9ja2VyLnYxLlJlbW92ZUltYWdlUmVzcG9uc2UiABJRChBJbWFnZVBydW5lVW51c2VkEhwuZG9ja2VyLnYxLkltYWdlUHJ1bmVSZXF1ZXN0Gh0uZG9ja2VyLnYxLkltYWdlUHJ1bmVSZXNwb25zZSIAElEKDEltYWdlSW5zcGVjdBIeLmRvY2tlci52MS5JbWFnZUluc3BlY3RSZXF1ZXN0Gh8uZG9ja2VyLnYxLkltYWdlSW5zcGVjdFJlc3BvbnNlIgASTQoKVm9sdW1lTGlzdBIdLmRvY2tlci52MS5MaXN0Vm9sdW1lc1JlcXVlc3QaHi5kb2NrZXIudjEuTGlzdFZvbHVtZXNSZXNwb25zZSIAElEKDFZvbHVtZUNyZWF0ZRIeLmRvY2tlci52MS5DcmVhdGVWb2x1bWVSZXF1ZXN0Gh8uZG9ja2VyLnYxLkNyZWF0ZVZvbHVtZVJlc3BvbnNlIgASUQoMVm9sdW1lRGVsZXRlEh4uZG9ja2VyLnYxLkRlbGV0ZVZvbHVtZVJlcXVlc3QaHy5kb2NrZXIudjEuRGVsZXRlVm9sdW1lUmVzcG9uc2UiABJQCgtOZXR3b3JrTGlzdBIeLmRvY2tlci52MS5MaXN0TmV0d29ya3NSZXF1ZXN0Gh8uZG9ja2VyLnYxLkxpc3ROZXR3b3Jrc1Jlc3BvbnNlIgASVAoNTmV0d29ya0NyZWF0ZRIfLmRvY2tlci52MS5DcmVhdGVOZXR3b3JrUmVxdWVzdBogLmRvY2tlci52MS5DcmVhdGVOZXR3b3JrUmVzcG9uc2UiABJUCg1OZXR3b3JrRGVsZXRlEh8uZG9ja2VyLnYxLkRlbGV0ZU5ldHdvcmtSZXF1ZXN0GiAuZG9ja2VyLnYxLkRlbGV0ZU5ldHdvcmtSZXNwb25zZSIAElcKDk5ldHdvcmtJbnNwZWN0EiAuZG9ja2VyLnYxLk5ldHdvcmtJbnNwZWN0UmVxdWVzdBohLmRvY2tlci52MS5OZXR3b3JrSW5zcGVjdFJlc3BvbnNlIgBCjwEKDWNvbS5kb2NrZXIudjFCC0RvY2tlclByb3RvUAFaLGdpdGh1Yi5jb20vUkEzNDEvZG9ja21hbi9nZW5lcmF0ZWQvZG9ja2VyL3YxogIDRFhYqgIJRG9ja2VyLlYxygIJRG9ja2VyXFYx4gIVRG9ja2VyXFYxXEdQQk1ldGFkYXRh6gIKRG9ja2VyOjpWMWIGcHJvdG8z");
 
 /**
  * @generated from message docker.v1.ComposeFileStatusRequest
@@ -525,6 +525,11 @@ export type ImageInspect = Message<"docker.v1.ImageInspect"> & {
    * @generated from field: repeated docker.v1.ImageLayer layers = 2;
    */
   layers: ImageLayer[];
+
+  /**
+   * @generated from field: repeated docker.v1.ImageContainerInspect containers = 7;
+   */
+  containers: ImageContainerInspect[];
 };
 
 /**
@@ -567,6 +572,38 @@ export const ImageLayerSchema: GenMessage<ImageLayer> = /*@__PURE__*/
   messageDesc(file_docker_v1_docker, 18);
 
 /**
+ * @generated from message docker.v1.ImageContainerInspect
+ */
+export type ImageContainerInspect = Message<"docker.v1.ImageContainerInspect"> & {
+  /**
+   * @generated from field: string name = 1;
+   */
+  name: string;
+
+  /**
+   * @generated from field: string id = 2;
+   */
+  id: string;
+
+  /**
+   * @generated from field: string state = 3;
+   */
+  state: string;
+
+  /**
+   * @generated from field: string composeProject = 4;
+   */
+  composeProject: string;
+};
+
+/**
+ * Describes the message docker.v1.ImageContainerInspect.
+ * Use `create(ImageContainerInspectSchema)` to create a new message.
+ */
+export const ImageContainerInspectSchema: GenMessage<ImageContainerInspect> = /*@__PURE__*/
+  messageDesc(file_docker_v1_docker, 19);
+
+/**
  * @generated from message docker.v1.ComposeValidateResponse
  */
 export type ComposeValidateResponse = Message<"docker.v1.ComposeValidateResponse"> & {
@@ -581,7 +618,7 @@ export type ComposeValidateResponse = Message<"docker.v1.ComposeValidateResponse
  * Use `create(ComposeValidateResponseSchema)` to create a new message.
  */
 export const ComposeValidateResponseSchema: GenMessage<ComposeValidateResponse> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 19);
+  messageDesc(file_docker_v1_docker, 20);
 
 /**
  * forwards commands from user to a running session
@@ -605,7 +642,7 @@ export type ContainerExecCmdInput = Message<"docker.v1.ContainerExecCmdInput"> &
  * Use `create(ContainerExecCmdInputSchema)` to create a new message.
  */
 export const ContainerExecCmdInputSchema: GenMessage<ContainerExecCmdInput> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 20);
+  messageDesc(file_docker_v1_docker, 21);
 
 /**
  * @generated from message docker.v1.ContainerExecRequest
@@ -629,7 +666,7 @@ export type ContainerExecRequest = Message<"docker.v1.ContainerExecRequest"> & {
  * Use `create(ContainerExecRequestSchema)` to create a new message.
  */
 export const ContainerExecRequestSchema: GenMessage<ContainerExecRequest> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 21);
+  messageDesc(file_docker_v1_docker, 22);
 
 /**
  * Image-related messages
@@ -698,7 +735,7 @@ export type Image = Message<"docker.v1.Image"> & {
  * Use `create(ImageSchema)` to create a new message.
  */
 export const ImageSchema: GenMessage<Image> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 22);
+  messageDesc(file_docker_v1_docker, 23);
 
 /**
  * @generated from message docker.v1.ManifestSummary
@@ -725,7 +762,7 @@ export type ManifestSummary = Message<"docker.v1.ManifestSummary"> & {
  * Use `create(ManifestSummarySchema)` to create a new message.
  */
 export const ManifestSummarySchema: GenMessage<ManifestSummary> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 23);
+  messageDesc(file_docker_v1_docker, 24);
 
 /**
  * @generated from message docker.v1.ListImagesRequest
@@ -738,7 +775,7 @@ export type ListImagesRequest = Message<"docker.v1.ListImagesRequest"> & {
  * Use `create(ListImagesRequestSchema)` to create a new message.
  */
 export const ListImagesRequestSchema: GenMessage<ListImagesRequest> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 24);
+  messageDesc(file_docker_v1_docker, 25);
 
 /**
  * @generated from message docker.v1.ListImagesResponse
@@ -770,7 +807,7 @@ export type ListImagesResponse = Message<"docker.v1.ListImagesResponse"> & {
  * Use `create(ListImagesResponseSchema)` to create a new message.
  */
 export const ListImagesResponseSchema: GenMessage<ListImagesResponse> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 25);
+  messageDesc(file_docker_v1_docker, 26);
 
 /**
  * @generated from message docker.v1.RemoveImageRequest
@@ -792,7 +829,7 @@ export type RemoveImageRequest = Message<"docker.v1.RemoveImageRequest"> & {
  * Use `create(RemoveImageRequestSchema)` to create a new message.
  */
 export const RemoveImageRequestSchema: GenMessage<RemoveImageRequest> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 26);
+  messageDesc(file_docker_v1_docker, 27);
 
 /**
  * @generated from message docker.v1.RemoveImageResponse
@@ -805,7 +842,7 @@ export type RemoveImageResponse = Message<"docker.v1.RemoveImageResponse"> & {
  * Use `create(RemoveImageResponseSchema)` to create a new message.
  */
 export const RemoveImageResponseSchema: GenMessage<RemoveImageResponse> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 27);
+  messageDesc(file_docker_v1_docker, 28);
 
 /**
  * @generated from message docker.v1.ImagePruneResponse
@@ -827,7 +864,7 @@ export type ImagePruneResponse = Message<"docker.v1.ImagePruneResponse"> & {
  * Use `create(ImagePruneResponseSchema)` to create a new message.
  */
 export const ImagePruneResponseSchema: GenMessage<ImagePruneResponse> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 28);
+  messageDesc(file_docker_v1_docker, 29);
 
 /**
  * @generated from message docker.v1.ImagePruneRequest
@@ -849,7 +886,7 @@ export type ImagePruneRequest = Message<"docker.v1.ImagePruneRequest"> & {
  * Use `create(ImagePruneRequestSchema)` to create a new message.
  */
 export const ImagePruneRequestSchema: GenMessage<ImagePruneRequest> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 29);
+  messageDesc(file_docker_v1_docker, 30);
 
 /**
  * @generated from message docker.v1.ImagesDeleted
@@ -871,7 +908,7 @@ export type ImagesDeleted = Message<"docker.v1.ImagesDeleted"> & {
  * Use `create(ImagesDeletedSchema)` to create a new message.
  */
 export const ImagesDeletedSchema: GenMessage<ImagesDeleted> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 30);
+  messageDesc(file_docker_v1_docker, 31);
 
 /**
  * Volume-related messages
@@ -925,7 +962,7 @@ export type Volume = Message<"docker.v1.Volume"> & {
  * Use `create(VolumeSchema)` to create a new message.
  */
 export const VolumeSchema: GenMessage<Volume> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 31);
+  messageDesc(file_docker_v1_docker, 32);
 
 /**
  * @generated from message docker.v1.ListVolumesRequest
@@ -938,7 +975,7 @@ export type ListVolumesRequest = Message<"docker.v1.ListVolumesRequest"> & {
  * Use `create(ListVolumesRequestSchema)` to create a new message.
  */
 export const ListVolumesRequestSchema: GenMessage<ListVolumesRequest> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 32);
+  messageDesc(file_docker_v1_docker, 33);
 
 /**
  * @generated from message docker.v1.ListVolumesResponse
@@ -955,7 +992,7 @@ export type ListVolumesResponse = Message<"docker.v1.ListVolumesResponse"> & {
  * Use `create(ListVolumesResponseSchema)` to create a new message.
  */
 export const ListVolumesResponseSchema: GenMessage<ListVolumesResponse> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 33);
+  messageDesc(file_docker_v1_docker, 34);
 
 /**
  * @generated from message docker.v1.CreateVolumeRequest
@@ -968,7 +1005,7 @@ export type CreateVolumeRequest = Message<"docker.v1.CreateVolumeRequest"> & {
  * Use `create(CreateVolumeRequestSchema)` to create a new message.
  */
 export const CreateVolumeRequestSchema: GenMessage<CreateVolumeRequest> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 34);
+  messageDesc(file_docker_v1_docker, 35);
 
 /**
  * @generated from message docker.v1.CreateVolumeResponse
@@ -981,7 +1018,7 @@ export type CreateVolumeResponse = Message<"docker.v1.CreateVolumeResponse"> & {
  * Use `create(CreateVolumeResponseSchema)` to create a new message.
  */
 export const CreateVolumeResponseSchema: GenMessage<CreateVolumeResponse> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 35);
+  messageDesc(file_docker_v1_docker, 36);
 
 /**
  * @generated from message docker.v1.DeleteVolumeRequest
@@ -1013,7 +1050,7 @@ export type DeleteVolumeRequest = Message<"docker.v1.DeleteVolumeRequest"> & {
  * Use `create(DeleteVolumeRequestSchema)` to create a new message.
  */
 export const DeleteVolumeRequestSchema: GenMessage<DeleteVolumeRequest> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 36);
+  messageDesc(file_docker_v1_docker, 37);
 
 /**
  * @generated from message docker.v1.DeleteVolumeResponse
@@ -1026,7 +1063,7 @@ export type DeleteVolumeResponse = Message<"docker.v1.DeleteVolumeResponse"> & {
  * Use `create(DeleteVolumeResponseSchema)` to create a new message.
  */
 export const DeleteVolumeResponseSchema: GenMessage<DeleteVolumeResponse> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 37);
+  messageDesc(file_docker_v1_docker, 38);
 
 /**
  * Network-related messages
@@ -1100,7 +1137,7 @@ export type Network = Message<"docker.v1.Network"> & {
  * Use `create(NetworkSchema)` to create a new message.
  */
 export const NetworkSchema: GenMessage<Network> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 38);
+  messageDesc(file_docker_v1_docker, 39);
 
 /**
  * @generated from message docker.v1.ListNetworksRequest
@@ -1113,7 +1150,7 @@ export type ListNetworksRequest = Message<"docker.v1.ListNetworksRequest"> & {
  * Use `create(ListNetworksRequestSchema)` to create a new message.
  */
 export const ListNetworksRequestSchema: GenMessage<ListNetworksRequest> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 39);
+  messageDesc(file_docker_v1_docker, 40);
 
 /**
  * @generated from message docker.v1.ListNetworksResponse
@@ -1130,7 +1167,7 @@ export type ListNetworksResponse = Message<"docker.v1.ListNetworksResponse"> & {
  * Use `create(ListNetworksResponseSchema)` to create a new message.
  */
 export const ListNetworksResponseSchema: GenMessage<ListNetworksResponse> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 40);
+  messageDesc(file_docker_v1_docker, 41);
 
 /**
  * @generated from message docker.v1.CreateNetworkRequest
@@ -1143,7 +1180,7 @@ export type CreateNetworkRequest = Message<"docker.v1.CreateNetworkRequest"> & {
  * Use `create(CreateNetworkRequestSchema)` to create a new message.
  */
 export const CreateNetworkRequestSchema: GenMessage<CreateNetworkRequest> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 41);
+  messageDesc(file_docker_v1_docker, 42);
 
 /**
  * @generated from message docker.v1.CreateNetworkResponse
@@ -1156,7 +1193,7 @@ export type CreateNetworkResponse = Message<"docker.v1.CreateNetworkResponse"> &
  * Use `create(CreateNetworkResponseSchema)` to create a new message.
  */
 export const CreateNetworkResponseSchema: GenMessage<CreateNetworkResponse> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 42);
+  messageDesc(file_docker_v1_docker, 43);
 
 /**
  * @generated from message docker.v1.DeleteNetworkRequest
@@ -1178,7 +1215,7 @@ export type DeleteNetworkRequest = Message<"docker.v1.DeleteNetworkRequest"> & {
  * Use `create(DeleteNetworkRequestSchema)` to create a new message.
  */
 export const DeleteNetworkRequestSchema: GenMessage<DeleteNetworkRequest> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 43);
+  messageDesc(file_docker_v1_docker, 44);
 
 /**
  * @generated from message docker.v1.DeleteNetworkResponse
@@ -1191,7 +1228,7 @@ export type DeleteNetworkResponse = Message<"docker.v1.DeleteNetworkResponse"> &
  * Use `create(DeleteNetworkResponseSchema)` to create a new message.
  */
 export const DeleteNetworkResponseSchema: GenMessage<DeleteNetworkResponse> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 44);
+  messageDesc(file_docker_v1_docker, 45);
 
 /**
  * @generated from message docker.v1.ContainerLogsRequest
@@ -1208,7 +1245,7 @@ export type ContainerLogsRequest = Message<"docker.v1.ContainerLogsRequest"> & {
  * Use `create(ContainerLogsRequestSchema)` to create a new message.
  */
 export const ContainerLogsRequestSchema: GenMessage<ContainerLogsRequest> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 45);
+  messageDesc(file_docker_v1_docker, 46);
 
 /**
  * @generated from message docker.v1.LogsMessage
@@ -1225,7 +1262,7 @@ export type LogsMessage = Message<"docker.v1.LogsMessage"> & {
  * Use `create(LogsMessageSchema)` to create a new message.
  */
 export const LogsMessageSchema: GenMessage<LogsMessage> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 46);
+  messageDesc(file_docker_v1_docker, 47);
 
 /**
  * @generated from message docker.v1.StatsResponse
@@ -1247,7 +1284,7 @@ export type StatsResponse = Message<"docker.v1.StatsResponse"> & {
  * Use `create(StatsResponseSchema)` to create a new message.
  */
 export const StatsResponseSchema: GenMessage<StatsResponse> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 47);
+  messageDesc(file_docker_v1_docker, 48);
 
 /**
  * @generated from message docker.v1.StatsRequest
@@ -1279,7 +1316,7 @@ export type StatsRequest = Message<"docker.v1.StatsRequest"> & {
  * Use `create(StatsRequestSchema)` to create a new message.
  */
 export const StatsRequestSchema: GenMessage<StatsRequest> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 48);
+  messageDesc(file_docker_v1_docker, 49);
 
 /**
  * @generated from message docker.v1.SystemInfo
@@ -1303,7 +1340,7 @@ export type SystemInfo = Message<"docker.v1.SystemInfo"> & {
  * Use `create(SystemInfoSchema)` to create a new message.
  */
 export const SystemInfoSchema: GenMessage<SystemInfo> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 49);
+  messageDesc(file_docker_v1_docker, 50);
 
 /**
  * @generated from message docker.v1.ListResponse
@@ -1325,7 +1362,7 @@ export type ListResponse = Message<"docker.v1.ListResponse"> & {
  * Use `create(ListResponseSchema)` to create a new message.
  */
 export const ListResponseSchema: GenMessage<ListResponse> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 50);
+  messageDesc(file_docker_v1_docker, 51);
 
 /**
  * @generated from message docker.v1.ContainerList
@@ -1404,7 +1441,7 @@ export type ContainerList = Message<"docker.v1.ContainerList"> & {
  * Use `create(ContainerListSchema)` to create a new message.
  */
 export const ContainerListSchema: GenMessage<ContainerList> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 51);
+  messageDesc(file_docker_v1_docker, 52);
 
 /**
  * ContainerInfo holds metrics for a single Docker container.
@@ -1481,7 +1518,7 @@ export type ContainerStats = Message<"docker.v1.ContainerStats"> & {
  * Use `create(ContainerStatsSchema)` to create a new message.
  */
 export const ContainerStatsSchema: GenMessage<ContainerStats> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 52);
+  messageDesc(file_docker_v1_docker, 53);
 
 /**
  * @generated from message docker.v1.Port
@@ -1513,7 +1550,7 @@ export type Port = Message<"docker.v1.Port"> & {
  * Use `create(PortSchema)` to create a new message.
  */
 export const PortSchema: GenMessage<Port> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 53);
+  messageDesc(file_docker_v1_docker, 54);
 
 /**
  * @generated from message docker.v1.Empty
@@ -1526,7 +1563,7 @@ export type Empty = Message<"docker.v1.Empty"> & {
  * Use `create(EmptySchema)` to create a new message.
  */
 export const EmptySchema: GenMessage<Empty> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 54);
+  messageDesc(file_docker_v1_docker, 55);
 
 /**
  * @generated from message docker.v1.ContainerRequest
@@ -1543,7 +1580,7 @@ export type ContainerRequest = Message<"docker.v1.ContainerRequest"> & {
  * Use `create(ContainerRequestSchema)` to create a new message.
  */
 export const ContainerRequestSchema: GenMessage<ContainerRequest> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 55);
+  messageDesc(file_docker_v1_docker, 56);
 
 /**
  * @generated from message docker.v1.ComposeFile
@@ -1565,7 +1602,7 @@ export type ComposeFile = Message<"docker.v1.ComposeFile"> & {
  * Use `create(ComposeFileSchema)` to create a new message.
  */
 export const ComposeFileSchema: GenMessage<ComposeFile> = /*@__PURE__*/
-  messageDesc(file_docker_v1_docker, 56);
+  messageDesc(file_docker_v1_docker, 57);
 
 /**
  * @generated from enum docker.v1.SORT_FIELD

--- a/ui/src/pages/images/inspect.tsx
+++ b/ui/src/pages/images/inspect.tsx
@@ -220,76 +220,6 @@ const ImageInspectPage = () => {
                             </Stack>
                         </Paper>
 
-                        {/* Layers Table */}
-                        <Paper variant="outlined"
-                               sx={{
-                                   // width: 800,
-                                   borderRadius: 3,
-                                   overflow: 'hidden',
-                                   display: 'flex',
-                                   flexDirection: 'column'
-                               }}>
-                            <Box sx={{
-                                p: 2,
-                                display: 'flex',
-                                alignItems: 'center',
-                                justifyContent: 'space-between',
-                                bgcolor: 'background.paper'
-                            }}>
-                                <Stack direction="row" spacing={1} alignItems="center">
-                                    <HistoryOutlined sx={{fontSize: 18, color: 'text.disabled'}}/>
-                                    <Typography variant="subtitle2" sx={{fontWeight: 800}}>History Layers</Typography>
-                                    <Chip
-                                        label={`${inspect.layers?.length || 0} layers`}
-                                        size="small"
-                                        color="info"
-                                        sx={{height: 20, fontSize: '0.65rem', fontWeight: 700}}
-                                    />
-                                </Stack>
-                            </Box>
-
-                            <TableContainer sx={{...scrollbarStyles}}>
-                                <Table size="small" stickyHeader
-                                       sx={{tableLayout: 'fixed'}}> {/* Added fixed layout for strict width control */}
-                                    <TableHead>
-                                        <TableRow>
-                                            {/* Fixed small widths for metadata */}
-                                            <TableCell sx={{...headerStyles, width: 50}}>#</TableCell>
-                                            <TableCell sx={{...headerStyles, width: 120}}>Layer Size</TableCell>
-                                            <TableCell sx={{...headerStyles, width: 150}}>Cumulative</TableCell>
-                                            {/* Max width on the header */}
-                                            <TableCell sx={{...headerStyles, maxWidth: '500px'}}>Cmd</TableCell>
-                                        </TableRow>
-                                    </TableHead>
-                                    <TableBody>
-                                        {inspect.layers?.map((layer, idx) => (
-                                            <TableRow key={idx} hover>
-                                                <TableCell sx={{
-                                                    color: 'text.disabled',
-                                                    fontFamily: 'monospace',
-                                                    fontSize: '0.7rem'
-                                                }}>
-                                                    {idx}
-                                                </TableCell>
-                                                <TableCell>
-                                                    <LayerSizeChip size={layer.size}/>
-                                                </TableCell>
-                                                <TableCell sx={{
-                                                    color: 'text.secondary',
-                                                    fontFamily: 'monospace',
-                                                    fontSize: '0.75rem'
-                                                }}>
-                                                    {layer.totalSizeAtLayer || '--'}
-                                                </TableCell>
-                                                {/* The Cell component now handles its own internal constraints */}
-                                                <DockerCommandCell command={layer.cmd || ''}/>
-                                            </TableRow>
-                                        ))}
-                                    </TableBody>
-                                </Table>
-                            </TableContainer>
-                        </Paper>
-
                         {/* Containers using this image */}
                         <Paper variant="outlined"
                                sx={{
@@ -383,6 +313,77 @@ const ImageInspectPage = () => {
                                 </Box>
                             )}
                         </Paper>
+
+                        {/* Layers Table */}
+                        <Paper variant="outlined"
+                               sx={{
+                                   // width: 800,
+                                   borderRadius: 3,
+                                   overflow: 'hidden',
+                                   display: 'flex',
+                                   flexDirection: 'column'
+                               }}>
+                            <Box sx={{
+                                p: 2,
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'space-between',
+                                bgcolor: 'background.paper'
+                            }}>
+                                <Stack direction="row" spacing={1} alignItems="center">
+                                    <HistoryOutlined sx={{fontSize: 18, color: 'text.disabled'}}/>
+                                    <Typography variant="subtitle2" sx={{fontWeight: 800}}>History Layers</Typography>
+                                    <Chip
+                                        label={`${inspect.layers?.length || 0} layers`}
+                                        size="small"
+                                        color="info"
+                                        sx={{height: 20, fontSize: '0.65rem', fontWeight: 700}}
+                                    />
+                                </Stack>
+                            </Box>
+
+                            <TableContainer sx={{...scrollbarStyles}}>
+                                <Table size="small" stickyHeader
+                                       sx={{tableLayout: 'fixed'}}> {/* Added fixed layout for strict width control */}
+                                    <TableHead>
+                                        <TableRow>
+                                            {/* Fixed small widths for metadata */}
+                                            <TableCell sx={{...headerStyles, width: 50}}>#</TableCell>
+                                            <TableCell sx={{...headerStyles, width: 120}}>Layer Size</TableCell>
+                                            <TableCell sx={{...headerStyles, width: 150}}>Cumulative</TableCell>
+                                            {/* Max width on the header */}
+                                            <TableCell sx={{...headerStyles, maxWidth: '500px'}}>Cmd</TableCell>
+                                        </TableRow>
+                                    </TableHead>
+                                    <TableBody>
+                                        {inspect.layers?.map((layer, idx) => (
+                                            <TableRow key={idx} hover>
+                                                <TableCell sx={{
+                                                    color: 'text.disabled',
+                                                    fontFamily: 'monospace',
+                                                    fontSize: '0.7rem'
+                                                }}>
+                                                    {idx}
+                                                </TableCell>
+                                                <TableCell>
+                                                    <LayerSizeChip size={layer.size}/>
+                                                </TableCell>
+                                                <TableCell sx={{
+                                                    color: 'text.secondary',
+                                                    fontFamily: 'monospace',
+                                                    fontSize: '0.75rem'
+                                                }}>
+                                                    {layer.totalSizeAtLayer || '--'}
+                                                </TableCell>
+                                                {/* The Cell component now handles its own internal constraints */}
+                                                <DockerCommandCell command={layer.cmd || ''}/>
+                                            </TableRow>
+                                        ))}
+                                    </TableBody>
+                                </Table>
+                            </TableContainer>
+                        </Paper>
+
                     </>
                 )}
             </Box>

--- a/ui/src/pages/images/inspect.tsx
+++ b/ui/src/pages/images/inspect.tsx
@@ -25,7 +25,7 @@ import {
 import scrollbarStyles from "../../components/scrollbar-style.tsx";
 import RefreshIcon from '@mui/icons-material/Refresh';
 import ImageOutlinedIcon from '@mui/icons-material/ImageOutlined';
-import {ArrowBack, HistoryOutlined} from "@mui/icons-material";
+import {ArrowBack, HistoryOutlined, Inventory2Outlined} from "@mui/icons-material";
 
 const ImageInspectPage = () => {
     const dockerService = useHostClient(DockerService);
@@ -281,6 +281,100 @@ const ImageInspectPage = () => {
                                 </Table>
                             </TableContainer>
                         </Paper>
+
+                        {/* Containers using this image */}
+                        <Paper variant="outlined"
+                               sx={{
+                                   borderRadius: 3,
+                                   overflow: 'hidden',
+                                   display: 'flex',
+                                   flexDirection: 'column'
+                               }}>
+                            <Box sx={{
+                                p: 2,
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'space-between',
+                                bgcolor: 'background.paper'
+                            }}>
+                                <Stack direction="row" spacing={1} alignItems="center">
+                                    <Inventory2Outlined sx={{fontSize: 18, color: 'text.disabled'}}/>
+                                    <Typography variant="subtitle2" sx={{fontWeight: 800}}>Used By</Typography>
+                                    <Chip
+                                        label={`${inspect.containers?.length || 0} containers`}
+                                        size="small"
+                                        color={inspect.containers?.length ? "success" : "default"}
+                                        sx={{height: 20, fontSize: '0.65rem', fontWeight: 700}}
+                                    />
+                                </Stack>
+                            </Box>
+
+                            {inspect.containers && inspect.containers.length > 0 ? (
+                                <TableContainer sx={{...scrollbarStyles}}>
+                                    <Table size="small" stickyHeader sx={{tableLayout: 'fixed'}}>
+                                        <TableHead>
+                                            <TableRow>
+                                                <TableCell sx={{...headerStyles}}>Container</TableCell>
+                                                <TableCell sx={{...headerStyles, width: 120}}>State</TableCell>
+                                                <TableCell sx={{...headerStyles, width: 180}}>Project</TableCell>
+                                                <TableCell sx={{...headerStyles, width: 130}}>ID</TableCell>
+                                            </TableRow>
+                                        </TableHead>
+                                        <TableBody>
+                                            {inspect.containers.map((c) => (
+                                                <TableRow key={c.id} hover>
+                                                    <TableCell sx={{
+                                                        fontWeight: 600,
+                                                        fontSize: '0.8rem',
+                                                        overflow: 'hidden',
+                                                        textOverflow: 'ellipsis',
+                                                        whiteSpace: 'nowrap'
+                                                    }}>
+                                                        {c.name || '—'}
+                                                    </TableCell>
+                                                    <TableCell>
+                                                        <Chip
+                                                            label={c.state || 'unknown'}
+                                                            size="small"
+                                                            variant="outlined"
+                                                            color={stateColor(c.state)}
+                                                            sx={{
+                                                                height: 18,
+                                                                fontSize: '0.65rem',
+                                                                fontWeight: 700,
+                                                                textTransform: 'capitalize'
+                                                            }}
+                                                        />
+                                                    </TableCell>
+                                                    <TableCell sx={{
+                                                        color: 'text.secondary',
+                                                        fontSize: '0.75rem',
+                                                        overflow: 'hidden',
+                                                        textOverflow: 'ellipsis',
+                                                        whiteSpace: 'nowrap'
+                                                    }}>
+                                                        {c.composeProject || '—'}
+                                                    </TableCell>
+                                                    <TableCell sx={{
+                                                        color: 'text.disabled',
+                                                        fontFamily: 'monospace',
+                                                        fontSize: '0.7rem'
+                                                    }}>
+                                                        {c.id.substring(0, 12)}
+                                                    </TableCell>
+                                                </TableRow>
+                                            ))}
+                                        </TableBody>
+                                    </Table>
+                                </TableContainer>
+                            ) : (
+                                <Box sx={{p: 3, textAlign: 'center'}}>
+                                    <Typography variant="body2" color="text.secondary">
+                                        No containers are using this image.
+                                    </Typography>
+                                </Box>
+                            )}
+                        </Paper>
                     </>
                 )}
             </Box>
@@ -294,6 +388,13 @@ const headerStyles = {
     textTransform: 'uppercase',
     letterSpacing: '0.05em',
     py: 1.5
+};
+
+const stateColor = (state: string): 'success' | 'error' | 'default' => {
+    const s = (state || '').toLowerCase();
+    if (s === 'running') return 'success';
+    if (s === 'exited' || s === 'dead') return 'error';
+    return 'default';
 };
 
 const DetailRow = ({label, value, mono}: { label: string, value: string, mono?: boolean }) => (

--- a/ui/src/pages/images/inspect.tsx
+++ b/ui/src/pages/images/inspect.tsx
@@ -114,11 +114,9 @@ const ImageInspectPage = () => {
             <Box sx={{
                 p: 3,
                 flexGrow: 1,
-                minHeight: 0, // let this flex child shrink so overflow:auto actually scrolls
-                overflow: 'auto',
-                display: 'flex',
-                flexDirection: 'column',
-                gap: 3
+                overflowY: 'auto',
+                position: 'relative',
+                ...scrollbarStyles
             }}>
                 {loading ? (
                     <Box sx={{
@@ -136,7 +134,7 @@ const ImageInspectPage = () => {
                 ) : err ? (
                     <Alert severity="error" variant="outlined" sx={{borderRadius: 2}}>{err}</Alert>
                 ) : inspect && (
-                    <>
+                    <Stack spacing={3}>
                         {/* Summary Info Cards */}
                         {/* Unified Image Summary Card */}
                         <Paper
@@ -384,7 +382,7 @@ const ImageInspectPage = () => {
                             </TableContainer>
                         </Paper>
 
-                    </>
+                    </Stack>
                 )}
             </Box>
         </Box>

--- a/ui/src/pages/images/inspect.tsx
+++ b/ui/src/pages/images/inspect.tsx
@@ -111,7 +111,15 @@ const ImageInspectPage = () => {
                 </Stack>
             </Paper>
 
-            <Box sx={{p: 3, flexGrow: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 3}}>
+            <Box sx={{
+                p: 3,
+                flexGrow: 1,
+                minHeight: 0, // let this flex child shrink so overflow:auto actually scrolls
+                overflow: 'auto',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 3
+            }}>
                 {loading ? (
                     <Box sx={{
                         display: 'flex',


### PR DESCRIPTION
## Problem

The image list shows an "N in use" count, but the image inspect view had no way to see *which* containers actually run the image.

## Change

- **proto**: `ImageInspect` gains `repeated ImageContainerInspect containers = 7` (new message: `name`, `id`, `state`, `composeProject`).
- **backend**: `ImageContainers(imageID)` lists containers via the daemon-side `ancestor` filter (the same lookup the updater already uses); the `ImageInspect` handler populates the new field.
- **ui**: `inspect.tsx` renders a "Used By" table (container / state / project / id) with an empty state, styled like the existing History Layers section.

Includes the regenerated protobuf stubs.
