### PR TITLE
feat(compose): configurable default stack tab via dockman.yml

### DIFF
--- a/core/generated/dockyaml/v1/dockyaml.pb.go
+++ b/core/generated/dockyaml/v1/dockyaml.pb.go
@@ -272,6 +272,7 @@ type DockmanYaml struct {
 	NetworkPage                *NetworkConfig         `protobuf:"bytes,3,opt,name=networkPage,proto3" json:"networkPage,omitempty"`
 	ImagePage                  *ImageConfig           `protobuf:"bytes,4,opt,name=imagePage,proto3" json:"imagePage,omitempty"`
 	ContainerPage              *ContainerConfig       `protobuf:"bytes,5,opt,name=containerPage,proto3" json:"containerPage,omitempty"`
+	ComposePage                *ComposeConfig         `protobuf:"bytes,11,opt,name=composePage,proto3" json:"composePage,omitempty"`
 	unknownFields              protoimpl.UnknownFields
 	sizeCache                  protoimpl.SizeCache
 }
@@ -369,6 +370,58 @@ func (x *DockmanYaml) GetContainerPage() *ContainerConfig {
 	return nil
 }
 
+func (x *DockmanYaml) GetComposePage() *ComposeConfig {
+	if x != nil {
+		return x.ComposePage
+	}
+	return nil
+}
+
+type ComposeConfig struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// tab shown when opening a compose stack: editor (default), deploy or stats
+	DefaultTab    string `protobuf:"bytes,1,opt,name=defaultTab,proto3" json:"defaultTab,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ComposeConfig) Reset() {
+	*x = ComposeConfig{}
+	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ComposeConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ComposeConfig) ProtoMessage() {}
+
+func (x *ComposeConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ComposeConfig.ProtoReflect.Descriptor instead.
+func (*ComposeConfig) Descriptor() ([]byte, []int) {
+	return file_dockyaml_v1_dockyaml_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *ComposeConfig) GetDefaultTab() string {
+	if x != nil {
+		return x.DefaultTab
+	}
+	return ""
+}
+
 type VolumesConfig struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Sort          *Sort                  `protobuf:"bytes,1,opt,name=sort,proto3" json:"sort,omitempty"`
@@ -378,7 +431,7 @@ type VolumesConfig struct {
 
 func (x *VolumesConfig) Reset() {
 	*x = VolumesConfig{}
-	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[7]
+	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -390,7 +443,7 @@ func (x *VolumesConfig) String() string {
 func (*VolumesConfig) ProtoMessage() {}
 
 func (x *VolumesConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[7]
+	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -403,7 +456,7 @@ func (x *VolumesConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VolumesConfig.ProtoReflect.Descriptor instead.
 func (*VolumesConfig) Descriptor() ([]byte, []int) {
-	return file_dockyaml_v1_dockyaml_proto_rawDescGZIP(), []int{7}
+	return file_dockyaml_v1_dockyaml_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *VolumesConfig) GetSort() *Sort {
@@ -422,7 +475,7 @@ type NetworkConfig struct {
 
 func (x *NetworkConfig) Reset() {
 	*x = NetworkConfig{}
-	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[8]
+	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -434,7 +487,7 @@ func (x *NetworkConfig) String() string {
 func (*NetworkConfig) ProtoMessage() {}
 
 func (x *NetworkConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[8]
+	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -447,7 +500,7 @@ func (x *NetworkConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NetworkConfig.ProtoReflect.Descriptor instead.
 func (*NetworkConfig) Descriptor() ([]byte, []int) {
-	return file_dockyaml_v1_dockyaml_proto_rawDescGZIP(), []int{8}
+	return file_dockyaml_v1_dockyaml_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *NetworkConfig) GetSort() *Sort {
@@ -466,7 +519,7 @@ type ImageConfig struct {
 
 func (x *ImageConfig) Reset() {
 	*x = ImageConfig{}
-	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[9]
+	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -478,7 +531,7 @@ func (x *ImageConfig) String() string {
 func (*ImageConfig) ProtoMessage() {}
 
 func (x *ImageConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[9]
+	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -491,7 +544,7 @@ func (x *ImageConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImageConfig.ProtoReflect.Descriptor instead.
 func (*ImageConfig) Descriptor() ([]byte, []int) {
-	return file_dockyaml_v1_dockyaml_proto_rawDescGZIP(), []int{9}
+	return file_dockyaml_v1_dockyaml_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *ImageConfig) GetSort() *Sort {
@@ -510,7 +563,7 @@ type ContainerConfig struct {
 
 func (x *ContainerConfig) Reset() {
 	*x = ContainerConfig{}
-	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[10]
+	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -522,7 +575,7 @@ func (x *ContainerConfig) String() string {
 func (*ContainerConfig) ProtoMessage() {}
 
 func (x *ContainerConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[10]
+	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -535,7 +588,7 @@ func (x *ContainerConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ContainerConfig.ProtoReflect.Descriptor instead.
 func (*ContainerConfig) Descriptor() ([]byte, []int) {
-	return file_dockyaml_v1_dockyaml_proto_rawDescGZIP(), []int{10}
+	return file_dockyaml_v1_dockyaml_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *ContainerConfig) GetSort() *Sort {
@@ -555,7 +608,7 @@ type Sort struct {
 
 func (x *Sort) Reset() {
 	*x = Sort{}
-	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[11]
+	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -567,7 +620,7 @@ func (x *Sort) String() string {
 func (*Sort) ProtoMessage() {}
 
 func (x *Sort) ProtoReflect() protoreflect.Message {
-	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[11]
+	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -580,7 +633,7 @@ func (x *Sort) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Sort.ProtoReflect.Descriptor instead.
 func (*Sort) Descriptor() ([]byte, []int) {
-	return file_dockyaml_v1_dockyaml_proto_rawDescGZIP(), []int{11}
+	return file_dockyaml_v1_dockyaml_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *Sort) GetSortOrder() string {
@@ -611,7 +664,7 @@ const file_dockyaml_v1_dockyaml_proto_rawDesc = "" +
 	"\bcontents\x18\x01 \x01(\fR\bcontents\"\x10\n" +
 	"\x0eGetYamlRequest\"?\n" +
 	"\x0fGetYamlResponse\x12,\n" +
-	"\x04dock\x18\x01 \x01(\v2\x18.dockyaml.v1.DockmanYamlR\x04dock\"\xbe\x04\n" +
+	"\x04dock\x18\x01 \x01(\v2\x18.dockyaml.v1.DockmanYamlR\x04dock\"\xfc\x04\n" +
 	"\vDockmanYaml\x12K\n" +
 	"\vcustomTools\x18\t \x03(\v2).dockyaml.v1.DockmanYaml.CustomToolsEntryR\vcustomTools\x12,\n" +
 	"\x11useComposeFolders\x18\x01 \x01(\bR\x11useComposeFolders\x12>\n" +
@@ -621,10 +674,15 @@ const file_dockyaml_v1_dockyaml_proto_rawDesc = "" +
 	"\vvolumesPage\x18\x02 \x01(\v2\x1a.dockyaml.v1.VolumesConfigR\vvolumesPage\x12<\n" +
 	"\vnetworkPage\x18\x03 \x01(\v2\x1a.dockyaml.v1.NetworkConfigR\vnetworkPage\x126\n" +
 	"\timagePage\x18\x04 \x01(\v2\x18.dockyaml.v1.ImageConfigR\timagePage\x12B\n" +
-	"\rcontainerPage\x18\x05 \x01(\v2\x1c.dockyaml.v1.ContainerConfigR\rcontainerPage\x1a>\n" +
+	"\rcontainerPage\x18\x05 \x01(\v2\x1c.dockyaml.v1.ContainerConfigR\rcontainerPage\x12<\n" +
+	"\vcomposePage\x18\v \x01(\v2\x1a.dockyaml.v1.ComposeConfigR\vcomposePage\x1a>\n" +
 	"\x10CustomToolsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"6\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"/\n" +
+	"\rComposeConfig\x12\x1e\n" +
+	"\n" +
+	"defaultTab\x18\x01 \x01(\tR\n" +
+	"defaultTab\"6\n" +
 	"\rVolumesConfig\x12%\n" +
 	"\x04sort\x18\x01 \x01(\v2\x11.dockyaml.v1.SortR\x04sort\"6\n" +
 	"\rNetworkConfig\x12%\n" +
@@ -654,7 +712,7 @@ func file_dockyaml_v1_dockyaml_proto_rawDescGZIP() []byte {
 	return file_dockyaml_v1_dockyaml_proto_rawDescData
 }
 
-var file_dockyaml_v1_dockyaml_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
+var file_dockyaml_v1_dockyaml_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
 var file_dockyaml_v1_dockyaml_proto_goTypes = []any{
 	(*SaveRequest)(nil),     // 0: dockyaml.v1.SaveRequest
 	(*SaveResponse)(nil),    // 1: dockyaml.v1.SaveResponse
@@ -663,35 +721,37 @@ var file_dockyaml_v1_dockyaml_proto_goTypes = []any{
 	(*GetYamlRequest)(nil),  // 4: dockyaml.v1.GetYamlRequest
 	(*GetYamlResponse)(nil), // 5: dockyaml.v1.GetYamlResponse
 	(*DockmanYaml)(nil),     // 6: dockyaml.v1.DockmanYaml
-	(*VolumesConfig)(nil),   // 7: dockyaml.v1.VolumesConfig
-	(*NetworkConfig)(nil),   // 8: dockyaml.v1.NetworkConfig
-	(*ImageConfig)(nil),     // 9: dockyaml.v1.ImageConfig
-	(*ContainerConfig)(nil), // 10: dockyaml.v1.ContainerConfig
-	(*Sort)(nil),            // 11: dockyaml.v1.Sort
-	nil,                     // 12: dockyaml.v1.DockmanYaml.CustomToolsEntry
+	(*ComposeConfig)(nil),   // 7: dockyaml.v1.ComposeConfig
+	(*VolumesConfig)(nil),   // 8: dockyaml.v1.VolumesConfig
+	(*NetworkConfig)(nil),   // 9: dockyaml.v1.NetworkConfig
+	(*ImageConfig)(nil),     // 10: dockyaml.v1.ImageConfig
+	(*ContainerConfig)(nil), // 11: dockyaml.v1.ContainerConfig
+	(*Sort)(nil),            // 12: dockyaml.v1.Sort
+	nil,                     // 13: dockyaml.v1.DockmanYaml.CustomToolsEntry
 }
 var file_dockyaml_v1_dockyaml_proto_depIdxs = []int32{
 	6,  // 0: dockyaml.v1.GetYamlResponse.dock:type_name -> dockyaml.v1.DockmanYaml
-	12, // 1: dockyaml.v1.DockmanYaml.customTools:type_name -> dockyaml.v1.DockmanYaml.CustomToolsEntry
-	7,  // 2: dockyaml.v1.DockmanYaml.volumesPage:type_name -> dockyaml.v1.VolumesConfig
-	8,  // 3: dockyaml.v1.DockmanYaml.networkPage:type_name -> dockyaml.v1.NetworkConfig
-	9,  // 4: dockyaml.v1.DockmanYaml.imagePage:type_name -> dockyaml.v1.ImageConfig
-	10, // 5: dockyaml.v1.DockmanYaml.containerPage:type_name -> dockyaml.v1.ContainerConfig
-	11, // 6: dockyaml.v1.VolumesConfig.sort:type_name -> dockyaml.v1.Sort
-	11, // 7: dockyaml.v1.NetworkConfig.sort:type_name -> dockyaml.v1.Sort
-	11, // 8: dockyaml.v1.ImageConfig.sort:type_name -> dockyaml.v1.Sort
-	11, // 9: dockyaml.v1.ContainerConfig.sort:type_name -> dockyaml.v1.Sort
-	2,  // 10: dockyaml.v1.DockyamlService.Get:input_type -> dockyaml.v1.GetRequest
-	0,  // 11: dockyaml.v1.DockyamlService.Save:input_type -> dockyaml.v1.SaveRequest
-	4,  // 12: dockyaml.v1.DockyamlService.GetYaml:input_type -> dockyaml.v1.GetYamlRequest
-	3,  // 13: dockyaml.v1.DockyamlService.Get:output_type -> dockyaml.v1.GetResponse
-	1,  // 14: dockyaml.v1.DockyamlService.Save:output_type -> dockyaml.v1.SaveResponse
-	5,  // 15: dockyaml.v1.DockyamlService.GetYaml:output_type -> dockyaml.v1.GetYamlResponse
-	13, // [13:16] is the sub-list for method output_type
-	10, // [10:13] is the sub-list for method input_type
-	10, // [10:10] is the sub-list for extension type_name
-	10, // [10:10] is the sub-list for extension extendee
-	0,  // [0:10] is the sub-list for field type_name
+	13, // 1: dockyaml.v1.DockmanYaml.customTools:type_name -> dockyaml.v1.DockmanYaml.CustomToolsEntry
+	8,  // 2: dockyaml.v1.DockmanYaml.volumesPage:type_name -> dockyaml.v1.VolumesConfig
+	9,  // 3: dockyaml.v1.DockmanYaml.networkPage:type_name -> dockyaml.v1.NetworkConfig
+	10, // 4: dockyaml.v1.DockmanYaml.imagePage:type_name -> dockyaml.v1.ImageConfig
+	11, // 5: dockyaml.v1.DockmanYaml.containerPage:type_name -> dockyaml.v1.ContainerConfig
+	7,  // 6: dockyaml.v1.DockmanYaml.composePage:type_name -> dockyaml.v1.ComposeConfig
+	12, // 7: dockyaml.v1.VolumesConfig.sort:type_name -> dockyaml.v1.Sort
+	12, // 8: dockyaml.v1.NetworkConfig.sort:type_name -> dockyaml.v1.Sort
+	12, // 9: dockyaml.v1.ImageConfig.sort:type_name -> dockyaml.v1.Sort
+	12, // 10: dockyaml.v1.ContainerConfig.sort:type_name -> dockyaml.v1.Sort
+	2,  // 11: dockyaml.v1.DockyamlService.Get:input_type -> dockyaml.v1.GetRequest
+	0,  // 12: dockyaml.v1.DockyamlService.Save:input_type -> dockyaml.v1.SaveRequest
+	4,  // 13: dockyaml.v1.DockyamlService.GetYaml:input_type -> dockyaml.v1.GetYamlRequest
+	3,  // 14: dockyaml.v1.DockyamlService.Get:output_type -> dockyaml.v1.GetResponse
+	1,  // 15: dockyaml.v1.DockyamlService.Save:output_type -> dockyaml.v1.SaveResponse
+	5,  // 16: dockyaml.v1.DockyamlService.GetYaml:output_type -> dockyaml.v1.GetYamlResponse
+	14, // [14:17] is the sub-list for method output_type
+	11, // [11:14] is the sub-list for method input_type
+	11, // [11:11] is the sub-list for extension type_name
+	11, // [11:11] is the sub-list for extension extendee
+	0,  // [0:11] is the sub-list for field type_name
 }
 
 func init() { file_dockyaml_v1_dockyaml_proto_init() }
@@ -705,7 +765,7 @@ func file_dockyaml_v1_dockyaml_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_dockyaml_v1_dockyaml_proto_rawDesc), len(file_dockyaml_v1_dockyaml_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   13,
+			NumMessages:   14,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/core/internal/dockyaml/dockyaml.go
+++ b/core/internal/dockyaml/dockyaml.go
@@ -27,6 +27,9 @@ var defaultDockmanYaml = DockmanYaml{
 			Order: "asc",
 		},
 	},
+	ComposePage: ComposeConfig{
+		DefaultTab: "editor",
+	},
 }
 
 type DockmanYaml struct {
@@ -53,6 +56,9 @@ type DockmanYaml struct {
 
 	ContainerPage ContainerConfig `yaml:"containers"`
 
+	// configure the compose stack view
+	ComposePage ComposeConfig `yaml:"compose"`
+
 	// define a max search limit for files
 	SearchLimit int `yaml:"searchLimit"`
 
@@ -73,6 +79,11 @@ type NetworkConfig struct {
 
 type ImageConfig struct {
 	Sort Sort `yaml:"sort"`
+}
+
+type ComposeConfig struct {
+	// tab shown when opening a compose stack: editor (default), deploy or stats
+	DefaultTab string `yaml:"defaultTab"`
 }
 
 type Sort struct {

--- a/core/internal/dockyaml/handler.go
+++ b/core/internal/dockyaml/handler.go
@@ -71,6 +71,7 @@ func (d *DockmanYaml) ToProto() *v1.DockmanYaml {
 		NetworkPage:                d.NetworkPage.toProto(),
 		ImagePage:                  d.ImagePage.toProto(),
 		ContainerPage:              d.ContainerPage.toProto(),
+		ComposePage:                d.ComposePage.toProto(),
 	}
 }
 
@@ -102,5 +103,11 @@ func (n NetworkConfig) toProto() *v1.NetworkConfig {
 func (i ImageConfig) toProto() *v1.ImageConfig {
 	return &v1.ImageConfig{
 		Sort: i.Sort.toProto(),
+	}
+}
+
+func (c ComposeConfig) toProto() *v1.ComposeConfig {
+	return &v1.ComposeConfig{
+		DefaultTab: c.DefaultTab,
 	}
 }

--- a/spec/protos/dockyaml/v1/dockyaml.proto
+++ b/spec/protos/dockyaml/v1/dockyaml.proto
@@ -39,6 +39,12 @@ message DockmanYaml {
   NetworkConfig networkPage = 3;
   ImageConfig imagePage = 4;
   ContainerConfig containerPage = 5;
+  ComposeConfig composePage = 11;
+}
+
+message ComposeConfig {
+  // tab shown when opening a compose stack: editor (default), deploy or stats
+  string defaultTab = 1;
 }
 
 message VolumesConfig {

--- a/ui/src/context/tab-context.tsx
+++ b/ui/src/context/tab-context.tsx
@@ -1,6 +1,7 @@
 import {createContext, type ReactNode, useCallback, useContext, useEffect} from 'react'
 import {useLocation, useNavigate} from 'react-router-dom';
-import {useEditorUrl} from "../lib/editor.ts";
+import {stackDefaultTab, useEditorUrl} from "../lib/editor.ts";
+import {useConfig} from "../hooks/config.ts";
 import {create} from "zustand";
 import {immer} from "zustand/middleware/immer";
 import {useAliasStore, useHostStore} from "../pages/compose/state/files.ts";
@@ -172,7 +173,7 @@ export const useTabs = (): TabsContextType => {
 };
 
 export function TabsProvider({children}: { children: ReactNode }) {
-    // const {dockYaml} = useConfig()
+    const {dockYaml} = useConfig()
     // const tabLimit = dockYaml?.tabLimit ?? 5
 
     const location = useLocation();
@@ -183,16 +184,17 @@ export function TabsProvider({children}: { children: ReactNode }) {
     const {active, load, rename, update, create, close} = useTabsStore()
 
     const handleTabClick = useCallback((filename: string, track: number = 0) => {
-        const tabDetail = load(filename)
+        // files opened for the first time start on the dockman.yml default tab
+        const tabDetail = load(filename) ?? stackDefaultTab(dockYaml, filename)
         const url = editorUrl(filename, tabDetail, track);
         navigate(url);
-    }, [editorUrl, navigate, load]);
+    }, [editorUrl, navigate, load, dockYaml]);
 
     const handleOpenTab = useCallback((filename: string, track: number = 0) => {
         const params = new URLSearchParams(location.search);
-        create(filename, track, Number(params.get("tab") ?? "0"))
+        create(filename, track, Number(params.get("tab") ?? stackDefaultTab(dockYaml, filename)))
         active(filename, track)
-    }, [location.search, create, active]);
+    }, [location.search, create, active, dockYaml]);
 
     const handleCloseTab = useCallback((filename: string, track: number = 0) => {
         const {next, wasActive} = close(filename, track)

--- a/ui/src/gen/dockyaml/v1/dockyaml_pb.ts
+++ b/ui/src/gen/dockyaml/v1/dockyaml_pb.ts
@@ -10,7 +10,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file dockyaml/v1/dockyaml.proto.
  */
 export const file_dockyaml_v1_dockyaml: GenFile = /*@__PURE__*/
-  fileDesc("Chpkb2NreWFtbC92MS9kb2NreWFtbC5wcm90bxILZG9ja3lhbWwudjEiHwoLU2F2ZVJlcXVlc3QSEAoIY29udGVudHMYAiABKAwiDgoMU2F2ZVJlc3BvbnNlIgwKCkdldFJlcXVlc3QiHwoLR2V0UmVzcG9uc2USEAoIY29udGVudHMYASABKAwiEAoOR2V0WWFtbFJlcXVlc3QiOQoPR2V0WWFtbFJlc3BvbnNlEiYKBGRvY2sYASABKAsyGC5kb2NreWFtbC52MS5Eb2NrbWFuWWFtbCKrAwoLRG9ja21hbllhbWwSPgoLY3VzdG9tVG9vbHMYCSADKAsyKS5kb2NreWFtbC52MS5Eb2NrbWFuWWFtbC5DdXN0b21Ub29sc0VudHJ5EhkKEXVzZUNvbXBvc2VGb2xkZXJzGAEgASgIEiIKGmRpc2FibGVDb21wb3NlUXVpY2tBY3Rpb25zGAcgASgIEhMKC3NlYXJjaExpbWl0GAggASgFEhAKCHRhYkxpbWl0GAYgASgFEi8KC3ZvbHVtZXNQYWdlGAIgASgLMhouZG9ja3lhbWwudjEuVm9sdW1lc0NvbmZpZxIvCgtuZXR3b3JrUGFnZRgDIAEoCzIaLmRvY2t5YW1sLnYxLk5ldHdvcmtDb25maWcSKwoJaW1hZ2VQYWdlGAQgASgLMhguZG9ja3lhbWwudjEuSW1hZ2VDb25maWcSMwoNY29udGFpbmVyUGFnZRgFIAEoCzIcLmRvY2t5YW1sLnYxLkNvbnRhaW5lckNvbmZpZxoyChBDdXN0b21Ub29sc0VudHJ5EgsKA2tleRgBIAEoCRINCgV2YWx1ZRgCIAEoCToCOAEiMAoNVm9sdW1lc0NvbmZpZxIfCgRzb3J0GAEgASgLMhEuZG9ja3lhbWwudjEuU29ydCIwCg1OZXR3b3JrQ29uZmlnEh8KBHNvcnQYASABKAsyES5kb2NreWFtbC52MS5Tb3J0Ii4KC0ltYWdlQ29uZmlnEh8KBHNvcnQYASABKAsyES5kb2NreWFtbC52MS5Tb3J0IjIKD0NvbnRhaW5lckNvbmZpZxIfCgRzb3J0GAEgASgLMhEuZG9ja3lhbWwudjEuU29ydCIsCgRTb3J0EhEKCXNvcnRPcmRlchgBIAEoCRIRCglzb3J0RmllbGQYAiABKAky1AEKD0RvY2t5YW1sU2VydmljZRI6CgNHZXQSFy5kb2NreWFtbC52MS5HZXRSZXF1ZXN0GhguZG9ja3lhbWwudjEuR2V0UmVzcG9uc2UiABI9CgRTYXZlEhguZG9ja3lhbWwudjEuU2F2ZVJlcXVlc3QaGS5kb2NreWFtbC52MS5TYXZlUmVzcG9uc2UiABJGCgdHZXRZYW1sEhsuZG9ja3lhbWwudjEuR2V0WWFtbFJlcXVlc3QaHC5kb2NreWFtbC52MS5HZXRZYW1sUmVzcG9uc2UiAEKdAQoPY29tLmRvY2t5YW1sLnYxQg1Eb2NreWFtbFByb3RvUAFaLmdpdGh1Yi5jb20vUkEzNDEvZG9ja21hbi9nZW5lcmF0ZWQvZG9ja3lhbWwvdjGiAgNEWFiqAgtEb2NreWFtbC5WMcoCC0RvY2t5YW1sXFYx4gIXRG9ja3lhbWxcVjFcR1BCTWV0YWRhdGHqAgxEb2NreWFtbDo6VjFiBnByb3RvMw");
+  fileDesc("Chpkb2NreWFtbC92MS9kb2NreWFtbC5wcm90bxILZG9ja3lhbWwudjEiHwoLU2F2ZVJlcXVlc3QSEAoIY29udGVudHMYAiABKAwiDgoMU2F2ZVJlc3BvbnNlIgwKCkdldFJlcXVlc3QiHwoLR2V0UmVzcG9uc2USEAoIY29udGVudHMYASABKAwiEAoOR2V0WWFtbFJlcXVlc3QiOQoPR2V0WWFtbFJlc3BvbnNlEiYKBGRvY2sYASABKAsyGC5kb2NreWFtbC52MS5Eb2NrbWFuWWFtbCLcAwoLRG9ja21hbllhbWwSPgoLY3VzdG9tVG9vbHMYCSADKAsyKS5kb2NreWFtbC52MS5Eb2NrbWFuWWFtbC5DdXN0b21Ub29sc0VudHJ5EhkKEXVzZUNvbXBvc2VGb2xkZXJzGAEgASgIEiIKGmRpc2FibGVDb21wb3NlUXVpY2tBY3Rpb25zGAcgASgIEhMKC3NlYXJjaExpbWl0GAggASgFEhAKCHRhYkxpbWl0GAYgASgFEi8KC3ZvbHVtZXNQYWdlGAIgASgLMhouZG9ja3lhbWwudjEuVm9sdW1lc0NvbmZpZxIvCgtuZXR3b3JrUGFnZRgDIAEoCzIaLmRvY2t5YW1sLnYxLk5ldHdvcmtDb25maWcSKwoJaW1hZ2VQYWdlGAQgASgLMhguZG9ja3lhbWwudjEuSW1hZ2VDb25maWcSMwoNY29udGFpbmVyUGFnZRgFIAEoCzIcLmRvY2t5YW1sLnYxLkNvbnRhaW5lckNvbmZpZxIvCgtjb21wb3NlUGFnZRgLIAEoCzIaLmRvY2t5YW1sLnYxLkNvbXBvc2VDb25maWcaMgoQQ3VzdG9tVG9vbHNFbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAk6AjgBIiMKDUNvbXBvc2VDb25maWcSEgoKZGVmYXVsdFRhYhgBIAEoCSIwCg1Wb2x1bWVzQ29uZmlnEh8KBHNvcnQYASABKAsyES5kb2NreWFtbC52MS5Tb3J0IjAKDU5ldHdvcmtDb25maWcSHwoEc29ydBgBIAEoCzIRLmRvY2t5YW1sLnYxLlNvcnQiLgoLSW1hZ2VDb25maWcSHwoEc29ydBgBIAEoCzIRLmRvY2t5YW1sLnYxLlNvcnQiMgoPQ29udGFpbmVyQ29uZmlnEh8KBHNvcnQYASABKAsyES5kb2NreWFtbC52MS5Tb3J0IiwKBFNvcnQSEQoJc29ydE9yZGVyGAEgASgJEhEKCXNvcnRGaWVsZBgCIAEoCTLUAQoPRG9ja3lhbWxTZXJ2aWNlEjoKA0dldBIXLmRvY2t5YW1sLnYxLkdldFJlcXVlc3QaGC5kb2NreWFtbC52MS5HZXRSZXNwb25zZSIAEj0KBFNhdmUSGC5kb2NreWFtbC52MS5TYXZlUmVxdWVzdBoZLmRvY2t5YW1sLnYxLlNhdmVSZXNwb25zZSIAEkYKB0dldFlhbWwSGy5kb2NreWFtbC52MS5HZXRZYW1sUmVxdWVzdBocLmRvY2t5YW1sLnYxLkdldFlhbWxSZXNwb25zZSIAQp0BCg9jb20uZG9ja3lhbWwudjFCDURvY2t5YW1sUHJvdG9QAVouZ2l0aHViLmNvbS9SQTM0MS9kb2NrbWFuL2dlbmVyYXRlZC9kb2NreWFtbC92MaICA0RYWKoCC0RvY2t5YW1sLlYxygILRG9ja3lhbWxcVjHiAhdEb2NreWFtbFxWMVxHUEJNZXRhZGF0YeoCDERvY2t5YW1sOjpWMWIGcHJvdG8z");
 
 /**
  * @generated from message dockyaml.v1.SaveRequest
@@ -150,6 +150,11 @@ export type DockmanYaml = Message<"dockyaml.v1.DockmanYaml"> & {
    * @generated from field: dockyaml.v1.ContainerConfig containerPage = 5;
    */
   containerPage?: ContainerConfig;
+
+  /**
+   * @generated from field: dockyaml.v1.ComposeConfig composePage = 11;
+   */
+  composePage?: ComposeConfig;
 };
 
 /**
@@ -158,6 +163,25 @@ export type DockmanYaml = Message<"dockyaml.v1.DockmanYaml"> & {
  */
 export const DockmanYamlSchema: GenMessage<DockmanYaml> = /*@__PURE__*/
   messageDesc(file_dockyaml_v1_dockyaml, 6);
+
+/**
+ * @generated from message dockyaml.v1.ComposeConfig
+ */
+export type ComposeConfig = Message<"dockyaml.v1.ComposeConfig"> & {
+  /**
+   * tab shown when opening a compose stack: editor (default), deploy or stats
+   *
+   * @generated from field: string defaultTab = 1;
+   */
+  defaultTab: string;
+};
+
+/**
+ * Describes the message dockyaml.v1.ComposeConfig.
+ * Use `create(ComposeConfigSchema)` to create a new message.
+ */
+export const ComposeConfigSchema: GenMessage<ComposeConfig> = /*@__PURE__*/
+  messageDesc(file_dockyaml_v1_dockyaml, 7);
 
 /**
  * @generated from message dockyaml.v1.VolumesConfig
@@ -174,7 +198,7 @@ export type VolumesConfig = Message<"dockyaml.v1.VolumesConfig"> & {
  * Use `create(VolumesConfigSchema)` to create a new message.
  */
 export const VolumesConfigSchema: GenMessage<VolumesConfig> = /*@__PURE__*/
-  messageDesc(file_dockyaml_v1_dockyaml, 7);
+  messageDesc(file_dockyaml_v1_dockyaml, 8);
 
 /**
  * @generated from message dockyaml.v1.NetworkConfig
@@ -191,7 +215,7 @@ export type NetworkConfig = Message<"dockyaml.v1.NetworkConfig"> & {
  * Use `create(NetworkConfigSchema)` to create a new message.
  */
 export const NetworkConfigSchema: GenMessage<NetworkConfig> = /*@__PURE__*/
-  messageDesc(file_dockyaml_v1_dockyaml, 8);
+  messageDesc(file_dockyaml_v1_dockyaml, 9);
 
 /**
  * @generated from message dockyaml.v1.ImageConfig
@@ -208,7 +232,7 @@ export type ImageConfig = Message<"dockyaml.v1.ImageConfig"> & {
  * Use `create(ImageConfigSchema)` to create a new message.
  */
 export const ImageConfigSchema: GenMessage<ImageConfig> = /*@__PURE__*/
-  messageDesc(file_dockyaml_v1_dockyaml, 9);
+  messageDesc(file_dockyaml_v1_dockyaml, 10);
 
 /**
  * @generated from message dockyaml.v1.ContainerConfig
@@ -225,7 +249,7 @@ export type ContainerConfig = Message<"dockyaml.v1.ContainerConfig"> & {
  * Use `create(ContainerConfigSchema)` to create a new message.
  */
 export const ContainerConfigSchema: GenMessage<ContainerConfig> = /*@__PURE__*/
-  messageDesc(file_dockyaml_v1_dockyaml, 10);
+  messageDesc(file_dockyaml_v1_dockyaml, 11);
 
 /**
  * @generated from message dockyaml.v1.Sort
@@ -247,7 +271,7 @@ export type Sort = Message<"dockyaml.v1.Sort"> & {
  * Use `create(SortSchema)` to create a new message.
  */
 export const SortSchema: GenMessage<Sort> = /*@__PURE__*/
-  messageDesc(file_dockyaml_v1_dockyaml, 11);
+  messageDesc(file_dockyaml_v1_dockyaml, 12);
 
 /**
  * @generated from service dockyaml.v1.DockyamlService

--- a/ui/src/lib/editor.ts
+++ b/ui/src/lib/editor.ts
@@ -2,11 +2,28 @@ import type {TabDetails} from "../context/tab-context.tsx";
 import {useCallback} from "react";
 import {useLocation} from "react-router-dom";
 import {useAliasStore, useHostStore} from "../pages/compose/state/files.ts";
+import type {DockmanYaml} from "../gen/dockyaml/v1/dockyaml_pb.ts";
 
 export const COMPOSE_EXTENSIONS = ['compose.yaml', 'compose.yml']
 
 export function isComposeFile(filename: string): boolean {
     return COMPOSE_EXTENSIONS.some(ext => filename.endsWith(ext))
+}
+
+// Stack tab indexes by the names accepted in dockman.yml compose.defaultTab.
+const STACK_TAB_INDEXES: Record<string, number> = {
+    editor: 0,
+    deploy: 1,
+    stats: 2,
+}
+
+// Resolves the tab a file should open on when none is selected yet, per the
+// compose.defaultTab setting in dockman.yml. Non-compose files only have an
+// editor tab; unknown values fall back to the editor.
+export function stackDefaultTab(dockYaml: DockmanYaml | null | undefined, filename?: string): number {
+    if (!filename || !isComposeFile(filename)) return 0
+    const name = dockYaml?.composePage?.defaultTab?.trim().toLowerCase() ?? ''
+    return STACK_TAB_INDEXES[name] ?? 0
 }
 
 export const formatBytes = (bytes: number | bigint, decimals = 2) => {
@@ -48,6 +65,12 @@ export const useEditorUrl = () => {
         if (track === 0) {
             if (filename) {
                 path = `/${host}/files/${filename}`;
+                if (tabDetail === undefined) {
+                    // Opening a file without an explicit tab: drop the tab
+                    // inherited from the previous file so the view falls back
+                    // to the dockman.yml compose.defaultTab setting.
+                    query.delete(tabKey);
+                }
             } else if (!pathname.includes("/files/")) {
                 path = `/${host}/files/${prevAlias || "compose"}`;
             }

--- a/ui/src/pages/compose/components/viewer-text.tsx
+++ b/ui/src/pages/compose/components/viewer-text.tsx
@@ -3,7 +3,8 @@ import {useNavigate, useSearchParams} from 'react-router-dom';
 import {Box, Button, CircularProgress, Fade, Tab, Tabs, Tooltip} from '@mui/material';
 import {useFileComponents} from "../state/terminal.tsx";
 import {callRPC, useHostClient} from "../../../lib/api.ts";
-import {isComposeFile, useEditorUrl} from "../../../lib/editor.ts";
+import {isComposeFile, stackDefaultTab, useEditorUrl} from "../../../lib/editor.ts";
+import {useConfig} from "../../../hooks/config.ts";
 import TabEditor from "../tab-editor.tsx";
 import {ShortcutFormatter} from "./shortcut-formatter.tsx";
 import {TabDeploy} from "../tab-deploy.tsx";
@@ -43,9 +44,13 @@ function ViewerTextEditor({filename, track}: { filename: string, track: number }
     const fileService = useHostClient(FileService);
 
     const navigate = useNavigate();
+    const {dockYaml} = useConfig()
     const [searchParams] = useSearchParams();
     const tabKey = track === 0 ? 'tab' : 'splitTab';
-    const selectedTab = parseTabType(searchParams.get(tabKey))
+    // no tab selected in the url yet: open on the dockman.yml default tab
+    const selectedTab = parseTabType(
+        searchParams.get(tabKey) ?? String(stackDefaultTab(dockYaml, filename))
+    )
 
     const [isLoading, setIsLoading] = useState(true);
     const [fileError, setFileError] = useState("");


### PR DESCRIPTION
## What

Adds a `compose.defaultTab` setting to `dockman.yml` that controls which tab a compose stack opens on: `editor` (default), `deploy` or `stats`.

```yaml
compose:
  defaultTab: deploy
```

## Why

Stacks always open on the editor tab today — and worse, when you switch files the previously selected `?tab=` silently carries over to the next file. For deploy-first or monitoring-first workflows (open a stack → act on it), you had to click the tab you wanted every single time.

## How

- **proto**: new `ComposeConfig` message wired as `DockmanYaml.composePage` (regenerated stubs included)
- **core**: `ComposeConfig` yaml mapping with `defaultTab`, defaulted to `editor`, exposed through `ToProto()`
- **ui**: a `stackDefaultTab()` helper resolves the setting; opening a file without an explicitly selected tab now falls back to it:
  - `useEditorUrl` drops the inherited `?tab=` when navigating to a file with no explicit tab, so the default actually applies on every open
  - `TabsProvider` seeds newly opened tabs with the default instead of `0`
  - the viewer resolves the tab from the setting when the url has none

Behavior details:

- an explicit `?tab=` in the url always wins (deep links, tab clicks unchanged)
- non-compose files are unaffected — they only have an editor tab
- unknown/empty values fall back to `editor`
