### PR TITLE
fix(editor): end-of-file scroll behavior, sticky band overlay, widget panel width

### DIFF
--- a/core/generated/dockyaml/v1/dockyaml.pb.go
+++ b/core/generated/dockyaml/v1/dockyaml.pb.go
@@ -272,6 +272,7 @@ type DockmanYaml struct {
 	NetworkPage                *NetworkConfig         `protobuf:"bytes,3,opt,name=networkPage,proto3" json:"networkPage,omitempty"`
 	ImagePage                  *ImageConfig           `protobuf:"bytes,4,opt,name=imagePage,proto3" json:"imagePage,omitempty"`
 	ContainerPage              *ContainerConfig       `protobuf:"bytes,5,opt,name=containerPage,proto3" json:"containerPage,omitempty"`
+	EditorPage                 *EditorConfig          `protobuf:"bytes,12,opt,name=editorPage,proto3" json:"editorPage,omitempty"`
 	unknownFields              protoimpl.UnknownFields
 	sizeCache                  protoimpl.SizeCache
 }
@@ -369,6 +370,59 @@ func (x *DockmanYaml) GetContainerPage() *ContainerConfig {
 	return nil
 }
 
+func (x *DockmanYaml) GetEditorPage() *EditorConfig {
+	if x != nil {
+		return x.EditorPage
+	}
+	return nil
+}
+
+type EditorConfig struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// allow scrolling until the last line reaches the top of the view,
+	// for files taller than the viewport (classic Monaco behavior)
+	ScrollPastEnd bool `protobuf:"varint,1,opt,name=scrollPastEnd,proto3" json:"scrollPastEnd,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EditorConfig) Reset() {
+	*x = EditorConfig{}
+	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EditorConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EditorConfig) ProtoMessage() {}
+
+func (x *EditorConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EditorConfig.ProtoReflect.Descriptor instead.
+func (*EditorConfig) Descriptor() ([]byte, []int) {
+	return file_dockyaml_v1_dockyaml_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *EditorConfig) GetScrollPastEnd() bool {
+	if x != nil {
+		return x.ScrollPastEnd
+	}
+	return false
+}
+
 type VolumesConfig struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Sort          *Sort                  `protobuf:"bytes,1,opt,name=sort,proto3" json:"sort,omitempty"`
@@ -378,7 +432,7 @@ type VolumesConfig struct {
 
 func (x *VolumesConfig) Reset() {
 	*x = VolumesConfig{}
-	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[7]
+	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -390,7 +444,7 @@ func (x *VolumesConfig) String() string {
 func (*VolumesConfig) ProtoMessage() {}
 
 func (x *VolumesConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[7]
+	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -403,7 +457,7 @@ func (x *VolumesConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VolumesConfig.ProtoReflect.Descriptor instead.
 func (*VolumesConfig) Descriptor() ([]byte, []int) {
-	return file_dockyaml_v1_dockyaml_proto_rawDescGZIP(), []int{7}
+	return file_dockyaml_v1_dockyaml_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *VolumesConfig) GetSort() *Sort {
@@ -422,7 +476,7 @@ type NetworkConfig struct {
 
 func (x *NetworkConfig) Reset() {
 	*x = NetworkConfig{}
-	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[8]
+	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -434,7 +488,7 @@ func (x *NetworkConfig) String() string {
 func (*NetworkConfig) ProtoMessage() {}
 
 func (x *NetworkConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[8]
+	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -447,7 +501,7 @@ func (x *NetworkConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NetworkConfig.ProtoReflect.Descriptor instead.
 func (*NetworkConfig) Descriptor() ([]byte, []int) {
-	return file_dockyaml_v1_dockyaml_proto_rawDescGZIP(), []int{8}
+	return file_dockyaml_v1_dockyaml_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *NetworkConfig) GetSort() *Sort {
@@ -466,7 +520,7 @@ type ImageConfig struct {
 
 func (x *ImageConfig) Reset() {
 	*x = ImageConfig{}
-	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[9]
+	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -478,7 +532,7 @@ func (x *ImageConfig) String() string {
 func (*ImageConfig) ProtoMessage() {}
 
 func (x *ImageConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[9]
+	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -491,7 +545,7 @@ func (x *ImageConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImageConfig.ProtoReflect.Descriptor instead.
 func (*ImageConfig) Descriptor() ([]byte, []int) {
-	return file_dockyaml_v1_dockyaml_proto_rawDescGZIP(), []int{9}
+	return file_dockyaml_v1_dockyaml_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *ImageConfig) GetSort() *Sort {
@@ -510,7 +564,7 @@ type ContainerConfig struct {
 
 func (x *ContainerConfig) Reset() {
 	*x = ContainerConfig{}
-	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[10]
+	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -522,7 +576,7 @@ func (x *ContainerConfig) String() string {
 func (*ContainerConfig) ProtoMessage() {}
 
 func (x *ContainerConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[10]
+	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -535,7 +589,7 @@ func (x *ContainerConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ContainerConfig.ProtoReflect.Descriptor instead.
 func (*ContainerConfig) Descriptor() ([]byte, []int) {
-	return file_dockyaml_v1_dockyaml_proto_rawDescGZIP(), []int{10}
+	return file_dockyaml_v1_dockyaml_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *ContainerConfig) GetSort() *Sort {
@@ -555,7 +609,7 @@ type Sort struct {
 
 func (x *Sort) Reset() {
 	*x = Sort{}
-	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[11]
+	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -567,7 +621,7 @@ func (x *Sort) String() string {
 func (*Sort) ProtoMessage() {}
 
 func (x *Sort) ProtoReflect() protoreflect.Message {
-	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[11]
+	mi := &file_dockyaml_v1_dockyaml_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -580,7 +634,7 @@ func (x *Sort) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Sort.ProtoReflect.Descriptor instead.
 func (*Sort) Descriptor() ([]byte, []int) {
-	return file_dockyaml_v1_dockyaml_proto_rawDescGZIP(), []int{11}
+	return file_dockyaml_v1_dockyaml_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *Sort) GetSortOrder() string {
@@ -611,7 +665,7 @@ const file_dockyaml_v1_dockyaml_proto_rawDesc = "" +
 	"\bcontents\x18\x01 \x01(\fR\bcontents\"\x10\n" +
 	"\x0eGetYamlRequest\"?\n" +
 	"\x0fGetYamlResponse\x12,\n" +
-	"\x04dock\x18\x01 \x01(\v2\x18.dockyaml.v1.DockmanYamlR\x04dock\"\xbe\x04\n" +
+	"\x04dock\x18\x01 \x01(\v2\x18.dockyaml.v1.DockmanYamlR\x04dock\"\xf9\x04\n" +
 	"\vDockmanYaml\x12K\n" +
 	"\vcustomTools\x18\t \x03(\v2).dockyaml.v1.DockmanYaml.CustomToolsEntryR\vcustomTools\x12,\n" +
 	"\x11useComposeFolders\x18\x01 \x01(\bR\x11useComposeFolders\x12>\n" +
@@ -621,10 +675,15 @@ const file_dockyaml_v1_dockyaml_proto_rawDesc = "" +
 	"\vvolumesPage\x18\x02 \x01(\v2\x1a.dockyaml.v1.VolumesConfigR\vvolumesPage\x12<\n" +
 	"\vnetworkPage\x18\x03 \x01(\v2\x1a.dockyaml.v1.NetworkConfigR\vnetworkPage\x126\n" +
 	"\timagePage\x18\x04 \x01(\v2\x18.dockyaml.v1.ImageConfigR\timagePage\x12B\n" +
-	"\rcontainerPage\x18\x05 \x01(\v2\x1c.dockyaml.v1.ContainerConfigR\rcontainerPage\x1a>\n" +
+	"\rcontainerPage\x18\x05 \x01(\v2\x1c.dockyaml.v1.ContainerConfigR\rcontainerPage\x129\n" +
+	"\n" +
+	"editorPage\x18\f \x01(\v2\x19.dockyaml.v1.EditorConfigR\n" +
+	"editorPage\x1a>\n" +
 	"\x10CustomToolsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"6\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"4\n" +
+	"\fEditorConfig\x12$\n" +
+	"\rscrollPastEnd\x18\x01 \x01(\bR\rscrollPastEnd\"6\n" +
 	"\rVolumesConfig\x12%\n" +
 	"\x04sort\x18\x01 \x01(\v2\x11.dockyaml.v1.SortR\x04sort\"6\n" +
 	"\rNetworkConfig\x12%\n" +
@@ -654,7 +713,7 @@ func file_dockyaml_v1_dockyaml_proto_rawDescGZIP() []byte {
 	return file_dockyaml_v1_dockyaml_proto_rawDescData
 }
 
-var file_dockyaml_v1_dockyaml_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
+var file_dockyaml_v1_dockyaml_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
 var file_dockyaml_v1_dockyaml_proto_goTypes = []any{
 	(*SaveRequest)(nil),     // 0: dockyaml.v1.SaveRequest
 	(*SaveResponse)(nil),    // 1: dockyaml.v1.SaveResponse
@@ -663,35 +722,37 @@ var file_dockyaml_v1_dockyaml_proto_goTypes = []any{
 	(*GetYamlRequest)(nil),  // 4: dockyaml.v1.GetYamlRequest
 	(*GetYamlResponse)(nil), // 5: dockyaml.v1.GetYamlResponse
 	(*DockmanYaml)(nil),     // 6: dockyaml.v1.DockmanYaml
-	(*VolumesConfig)(nil),   // 7: dockyaml.v1.VolumesConfig
-	(*NetworkConfig)(nil),   // 8: dockyaml.v1.NetworkConfig
-	(*ImageConfig)(nil),     // 9: dockyaml.v1.ImageConfig
-	(*ContainerConfig)(nil), // 10: dockyaml.v1.ContainerConfig
-	(*Sort)(nil),            // 11: dockyaml.v1.Sort
-	nil,                     // 12: dockyaml.v1.DockmanYaml.CustomToolsEntry
+	(*EditorConfig)(nil),    // 7: dockyaml.v1.EditorConfig
+	(*VolumesConfig)(nil),   // 8: dockyaml.v1.VolumesConfig
+	(*NetworkConfig)(nil),   // 9: dockyaml.v1.NetworkConfig
+	(*ImageConfig)(nil),     // 10: dockyaml.v1.ImageConfig
+	(*ContainerConfig)(nil), // 11: dockyaml.v1.ContainerConfig
+	(*Sort)(nil),            // 12: dockyaml.v1.Sort
+	nil,                     // 13: dockyaml.v1.DockmanYaml.CustomToolsEntry
 }
 var file_dockyaml_v1_dockyaml_proto_depIdxs = []int32{
 	6,  // 0: dockyaml.v1.GetYamlResponse.dock:type_name -> dockyaml.v1.DockmanYaml
-	12, // 1: dockyaml.v1.DockmanYaml.customTools:type_name -> dockyaml.v1.DockmanYaml.CustomToolsEntry
-	7,  // 2: dockyaml.v1.DockmanYaml.volumesPage:type_name -> dockyaml.v1.VolumesConfig
-	8,  // 3: dockyaml.v1.DockmanYaml.networkPage:type_name -> dockyaml.v1.NetworkConfig
-	9,  // 4: dockyaml.v1.DockmanYaml.imagePage:type_name -> dockyaml.v1.ImageConfig
-	10, // 5: dockyaml.v1.DockmanYaml.containerPage:type_name -> dockyaml.v1.ContainerConfig
-	11, // 6: dockyaml.v1.VolumesConfig.sort:type_name -> dockyaml.v1.Sort
-	11, // 7: dockyaml.v1.NetworkConfig.sort:type_name -> dockyaml.v1.Sort
-	11, // 8: dockyaml.v1.ImageConfig.sort:type_name -> dockyaml.v1.Sort
-	11, // 9: dockyaml.v1.ContainerConfig.sort:type_name -> dockyaml.v1.Sort
-	2,  // 10: dockyaml.v1.DockyamlService.Get:input_type -> dockyaml.v1.GetRequest
-	0,  // 11: dockyaml.v1.DockyamlService.Save:input_type -> dockyaml.v1.SaveRequest
-	4,  // 12: dockyaml.v1.DockyamlService.GetYaml:input_type -> dockyaml.v1.GetYamlRequest
-	3,  // 13: dockyaml.v1.DockyamlService.Get:output_type -> dockyaml.v1.GetResponse
-	1,  // 14: dockyaml.v1.DockyamlService.Save:output_type -> dockyaml.v1.SaveResponse
-	5,  // 15: dockyaml.v1.DockyamlService.GetYaml:output_type -> dockyaml.v1.GetYamlResponse
-	13, // [13:16] is the sub-list for method output_type
-	10, // [10:13] is the sub-list for method input_type
-	10, // [10:10] is the sub-list for extension type_name
-	10, // [10:10] is the sub-list for extension extendee
-	0,  // [0:10] is the sub-list for field type_name
+	13, // 1: dockyaml.v1.DockmanYaml.customTools:type_name -> dockyaml.v1.DockmanYaml.CustomToolsEntry
+	8,  // 2: dockyaml.v1.DockmanYaml.volumesPage:type_name -> dockyaml.v1.VolumesConfig
+	9,  // 3: dockyaml.v1.DockmanYaml.networkPage:type_name -> dockyaml.v1.NetworkConfig
+	10, // 4: dockyaml.v1.DockmanYaml.imagePage:type_name -> dockyaml.v1.ImageConfig
+	11, // 5: dockyaml.v1.DockmanYaml.containerPage:type_name -> dockyaml.v1.ContainerConfig
+	7,  // 6: dockyaml.v1.DockmanYaml.editorPage:type_name -> dockyaml.v1.EditorConfig
+	12, // 7: dockyaml.v1.VolumesConfig.sort:type_name -> dockyaml.v1.Sort
+	12, // 8: dockyaml.v1.NetworkConfig.sort:type_name -> dockyaml.v1.Sort
+	12, // 9: dockyaml.v1.ImageConfig.sort:type_name -> dockyaml.v1.Sort
+	12, // 10: dockyaml.v1.ContainerConfig.sort:type_name -> dockyaml.v1.Sort
+	2,  // 11: dockyaml.v1.DockyamlService.Get:input_type -> dockyaml.v1.GetRequest
+	0,  // 12: dockyaml.v1.DockyamlService.Save:input_type -> dockyaml.v1.SaveRequest
+	4,  // 13: dockyaml.v1.DockyamlService.GetYaml:input_type -> dockyaml.v1.GetYamlRequest
+	3,  // 14: dockyaml.v1.DockyamlService.Get:output_type -> dockyaml.v1.GetResponse
+	1,  // 15: dockyaml.v1.DockyamlService.Save:output_type -> dockyaml.v1.SaveResponse
+	5,  // 16: dockyaml.v1.DockyamlService.GetYaml:output_type -> dockyaml.v1.GetYamlResponse
+	14, // [14:17] is the sub-list for method output_type
+	11, // [11:14] is the sub-list for method input_type
+	11, // [11:11] is the sub-list for extension type_name
+	11, // [11:11] is the sub-list for extension extendee
+	0,  // [0:11] is the sub-list for field type_name
 }
 
 func init() { file_dockyaml_v1_dockyaml_proto_init() }
@@ -705,7 +766,7 @@ func file_dockyaml_v1_dockyaml_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_dockyaml_v1_dockyaml_proto_rawDesc), len(file_dockyaml_v1_dockyaml_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   13,
+			NumMessages:   14,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/core/generated/dockyaml/v1/dockyaml.pb.go
+++ b/core/generated/dockyaml/v1/dockyaml.pb.go
@@ -379,8 +379,8 @@ func (x *DockmanYaml) GetEditorPage() *EditorConfig {
 
 type EditorConfig struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// allow scrolling until the last line reaches the top of the view,
-	// for files taller than the viewport (classic Monaco behavior)
+	// allow scrolling half a viewport past the last line (it stops at
+	// mid-view), for files taller than the viewport
 	ScrollPastEnd bool `protobuf:"varint,1,opt,name=scrollPastEnd,proto3" json:"scrollPastEnd,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/core/internal/dockyaml/dockyaml.go
+++ b/core/internal/dockyaml/dockyaml.go
@@ -53,6 +53,9 @@ type DockmanYaml struct {
 
 	ContainerPage ContainerConfig `yaml:"containers"`
 
+	// configure the file editor
+	EditorPage EditorConfig `yaml:"editor"`
+
 	// define a max search limit for files
 	SearchLimit int `yaml:"searchLimit"`
 
@@ -73,6 +76,12 @@ type NetworkConfig struct {
 
 type ImageConfig struct {
 	Sort Sort `yaml:"sort"`
+}
+
+type EditorConfig struct {
+	// allow scrolling until the last line reaches the top of the view,
+	// for files taller than the viewport (classic Monaco behavior)
+	ScrollPastEnd bool `yaml:"scrollPastEnd"`
 }
 
 type Sort struct {

--- a/core/internal/dockyaml/dockyaml.go
+++ b/core/internal/dockyaml/dockyaml.go
@@ -79,8 +79,8 @@ type ImageConfig struct {
 }
 
 type EditorConfig struct {
-	// allow scrolling until the last line reaches the top of the view,
-	// for files taller than the viewport (classic Monaco behavior)
+	// allow scrolling half a viewport past the last line (it stops at
+	// mid-view), for files taller than the viewport
 	ScrollPastEnd bool `yaml:"scrollPastEnd"`
 }
 

--- a/core/internal/dockyaml/handler.go
+++ b/core/internal/dockyaml/handler.go
@@ -71,6 +71,7 @@ func (d *DockmanYaml) ToProto() *v1.DockmanYaml {
 		NetworkPage:                d.NetworkPage.toProto(),
 		ImagePage:                  d.ImagePage.toProto(),
 		ContainerPage:              d.ContainerPage.toProto(),
+		EditorPage:                 d.EditorPage.toProto(),
 	}
 }
 
@@ -102,5 +103,11 @@ func (n NetworkConfig) toProto() *v1.NetworkConfig {
 func (i ImageConfig) toProto() *v1.ImageConfig {
 	return &v1.ImageConfig{
 		Sort: i.Sort.toProto(),
+	}
+}
+
+func (e EditorConfig) toProto() *v1.EditorConfig {
+	return &v1.EditorConfig{
+		ScrollPastEnd: e.ScrollPastEnd,
 	}
 }

--- a/spec/protos/dockyaml/v1/dockyaml.proto
+++ b/spec/protos/dockyaml/v1/dockyaml.proto
@@ -39,6 +39,13 @@ message DockmanYaml {
   NetworkConfig networkPage = 3;
   ImageConfig imagePage = 4;
   ContainerConfig containerPage = 5;
+  EditorConfig editorPage = 12;
+}
+
+message EditorConfig {
+  // allow scrolling until the last line reaches the top of the view,
+  // for files taller than the viewport (classic Monaco behavior)
+  bool scrollPastEnd = 1;
 }
 
 message VolumesConfig {

--- a/spec/protos/dockyaml/v1/dockyaml.proto
+++ b/spec/protos/dockyaml/v1/dockyaml.proto
@@ -43,8 +43,8 @@ message DockmanYaml {
 }
 
 message EditorConfig {
-  // allow scrolling until the last line reaches the top of the view,
-  // for files taller than the viewport (classic Monaco behavior)
+  // allow scrolling half a viewport past the last line (it stops at
+  // mid-view), for files taller than the viewport
   bool scrollPastEnd = 1;
 }
 

--- a/ui/src/gen/dockyaml/v1/dockyaml_pb.ts
+++ b/ui/src/gen/dockyaml/v1/dockyaml_pb.ts
@@ -169,8 +169,8 @@ export const DockmanYamlSchema: GenMessage<DockmanYaml> = /*@__PURE__*/
  */
 export type EditorConfig = Message<"dockyaml.v1.EditorConfig"> & {
   /**
-   * allow scrolling until the last line reaches the top of the view,
-   * for files taller than the viewport (classic Monaco behavior)
+   * allow scrolling half a viewport past the last line (it stops at
+   * mid-view), for files taller than the viewport
    *
    * @generated from field: bool scrollPastEnd = 1;
    */

--- a/ui/src/gen/dockyaml/v1/dockyaml_pb.ts
+++ b/ui/src/gen/dockyaml/v1/dockyaml_pb.ts
@@ -10,7 +10,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file dockyaml/v1/dockyaml.proto.
  */
 export const file_dockyaml_v1_dockyaml: GenFile = /*@__PURE__*/
-  fileDesc("Chpkb2NreWFtbC92MS9kb2NreWFtbC5wcm90bxILZG9ja3lhbWwudjEiHwoLU2F2ZVJlcXVlc3QSEAoIY29udGVudHMYAiABKAwiDgoMU2F2ZVJlc3BvbnNlIgwKCkdldFJlcXVlc3QiHwoLR2V0UmVzcG9uc2USEAoIY29udGVudHMYASABKAwiEAoOR2V0WWFtbFJlcXVlc3QiOQoPR2V0WWFtbFJlc3BvbnNlEiYKBGRvY2sYASABKAsyGC5kb2NreWFtbC52MS5Eb2NrbWFuWWFtbCKrAwoLRG9ja21hbllhbWwSPgoLY3VzdG9tVG9vbHMYCSADKAsyKS5kb2NreWFtbC52MS5Eb2NrbWFuWWFtbC5DdXN0b21Ub29sc0VudHJ5EhkKEXVzZUNvbXBvc2VGb2xkZXJzGAEgASgIEiIKGmRpc2FibGVDb21wb3NlUXVpY2tBY3Rpb25zGAcgASgIEhMKC3NlYXJjaExpbWl0GAggASgFEhAKCHRhYkxpbWl0GAYgASgFEi8KC3ZvbHVtZXNQYWdlGAIgASgLMhouZG9ja3lhbWwudjEuVm9sdW1lc0NvbmZpZxIvCgtuZXR3b3JrUGFnZRgDIAEoCzIaLmRvY2t5YW1sLnYxLk5ldHdvcmtDb25maWcSKwoJaW1hZ2VQYWdlGAQgASgLMhguZG9ja3lhbWwudjEuSW1hZ2VDb25maWcSMwoNY29udGFpbmVyUGFnZRgFIAEoCzIcLmRvY2t5YW1sLnYxLkNvbnRhaW5lckNvbmZpZxoyChBDdXN0b21Ub29sc0VudHJ5EgsKA2tleRgBIAEoCRINCgV2YWx1ZRgCIAEoCToCOAEiMAoNVm9sdW1lc0NvbmZpZxIfCgRzb3J0GAEgASgLMhEuZG9ja3lhbWwudjEuU29ydCIwCg1OZXR3b3JrQ29uZmlnEh8KBHNvcnQYASABKAsyES5kb2NreWFtbC52MS5Tb3J0Ii4KC0ltYWdlQ29uZmlnEh8KBHNvcnQYASABKAsyES5kb2NreWFtbC52MS5Tb3J0IjIKD0NvbnRhaW5lckNvbmZpZxIfCgRzb3J0GAEgASgLMhEuZG9ja3lhbWwudjEuU29ydCIsCgRTb3J0EhEKCXNvcnRPcmRlchgBIAEoCRIRCglzb3J0RmllbGQYAiABKAky1AEKD0RvY2t5YW1sU2VydmljZRI6CgNHZXQSFy5kb2NreWFtbC52MS5HZXRSZXF1ZXN0GhguZG9ja3lhbWwudjEuR2V0UmVzcG9uc2UiABI9CgRTYXZlEhguZG9ja3lhbWwudjEuU2F2ZVJlcXVlc3QaGS5kb2NreWFtbC52MS5TYXZlUmVzcG9uc2UiABJGCgdHZXRZYW1sEhsuZG9ja3lhbWwudjEuR2V0WWFtbFJlcXVlc3QaHC5kb2NreWFtbC52MS5HZXRZYW1sUmVzcG9uc2UiAEKdAQoPY29tLmRvY2t5YW1sLnYxQg1Eb2NreWFtbFByb3RvUAFaLmdpdGh1Yi5jb20vUkEzNDEvZG9ja21hbi9nZW5lcmF0ZWQvZG9ja3lhbWwvdjGiAgNEWFiqAgtEb2NreWFtbC5WMcoCC0RvY2t5YW1sXFYx4gIXRG9ja3lhbWxcVjFcR1BCTWV0YWRhdGHqAgxEb2NreWFtbDo6VjFiBnByb3RvMw");
+  fileDesc("Chpkb2NreWFtbC92MS9kb2NreWFtbC5wcm90bxILZG9ja3lhbWwudjEiHwoLU2F2ZVJlcXVlc3QSEAoIY29udGVudHMYAiABKAwiDgoMU2F2ZVJlc3BvbnNlIgwKCkdldFJlcXVlc3QiHwoLR2V0UmVzcG9uc2USEAoIY29udGVudHMYASABKAwiEAoOR2V0WWFtbFJlcXVlc3QiOQoPR2V0WWFtbFJlc3BvbnNlEiYKBGRvY2sYASABKAsyGC5kb2NreWFtbC52MS5Eb2NrbWFuWWFtbCLaAwoLRG9ja21hbllhbWwSPgoLY3VzdG9tVG9vbHMYCSADKAsyKS5kb2NreWFtbC52MS5Eb2NrbWFuWWFtbC5DdXN0b21Ub29sc0VudHJ5EhkKEXVzZUNvbXBvc2VGb2xkZXJzGAEgASgIEiIKGmRpc2FibGVDb21wb3NlUXVpY2tBY3Rpb25zGAcgASgIEhMKC3NlYXJjaExpbWl0GAggASgFEhAKCHRhYkxpbWl0GAYgASgFEi8KC3ZvbHVtZXNQYWdlGAIgASgLMhouZG9ja3lhbWwudjEuVm9sdW1lc0NvbmZpZxIvCgtuZXR3b3JrUGFnZRgDIAEoCzIaLmRvY2t5YW1sLnYxLk5ldHdvcmtDb25maWcSKwoJaW1hZ2VQYWdlGAQgASgLMhguZG9ja3lhbWwudjEuSW1hZ2VDb25maWcSMwoNY29udGFpbmVyUGFnZRgFIAEoCzIcLmRvY2t5YW1sLnYxLkNvbnRhaW5lckNvbmZpZxItCgplZGl0b3JQYWdlGAwgASgLMhkuZG9ja3lhbWwudjEuRWRpdG9yQ29uZmlnGjIKEEN1c3RvbVRvb2xzRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4ASIlCgxFZGl0b3JDb25maWcSFQoNc2Nyb2xsUGFzdEVuZBgBIAEoCCIwCg1Wb2x1bWVzQ29uZmlnEh8KBHNvcnQYASABKAsyES5kb2NreWFtbC52MS5Tb3J0IjAKDU5ldHdvcmtDb25maWcSHwoEc29ydBgBIAEoCzIRLmRvY2t5YW1sLnYxLlNvcnQiLgoLSW1hZ2VDb25maWcSHwoEc29ydBgBIAEoCzIRLmRvY2t5YW1sLnYxLlNvcnQiMgoPQ29udGFpbmVyQ29uZmlnEh8KBHNvcnQYASABKAsyES5kb2NreWFtbC52MS5Tb3J0IiwKBFNvcnQSEQoJc29ydE9yZGVyGAEgASgJEhEKCXNvcnRGaWVsZBgCIAEoCTLUAQoPRG9ja3lhbWxTZXJ2aWNlEjoKA0dldBIXLmRvY2t5YW1sLnYxLkdldFJlcXVlc3QaGC5kb2NreWFtbC52MS5HZXRSZXNwb25zZSIAEj0KBFNhdmUSGC5kb2NreWFtbC52MS5TYXZlUmVxdWVzdBoZLmRvY2t5YW1sLnYxLlNhdmVSZXNwb25zZSIAEkYKB0dldFlhbWwSGy5kb2NreWFtbC52MS5HZXRZYW1sUmVxdWVzdBocLmRvY2t5YW1sLnYxLkdldFlhbWxSZXNwb25zZSIAQp0BCg9jb20uZG9ja3lhbWwudjFCDURvY2t5YW1sUHJvdG9QAVouZ2l0aHViLmNvbS9SQTM0MS9kb2NrbWFuL2dlbmVyYXRlZC9kb2NreWFtbC92MaICA0RYWKoCC0RvY2t5YW1sLlYxygILRG9ja3lhbWxcVjHiAhdEb2NreWFtbFxWMVxHUEJNZXRhZGF0YeoCDERvY2t5YW1sOjpWMWIGcHJvdG8z");
 
 /**
  * @generated from message dockyaml.v1.SaveRequest
@@ -150,6 +150,11 @@ export type DockmanYaml = Message<"dockyaml.v1.DockmanYaml"> & {
    * @generated from field: dockyaml.v1.ContainerConfig containerPage = 5;
    */
   containerPage?: ContainerConfig;
+
+  /**
+   * @generated from field: dockyaml.v1.EditorConfig editorPage = 12;
+   */
+  editorPage?: EditorConfig;
 };
 
 /**
@@ -158,6 +163,26 @@ export type DockmanYaml = Message<"dockyaml.v1.DockmanYaml"> & {
  */
 export const DockmanYamlSchema: GenMessage<DockmanYaml> = /*@__PURE__*/
   messageDesc(file_dockyaml_v1_dockyaml, 6);
+
+/**
+ * @generated from message dockyaml.v1.EditorConfig
+ */
+export type EditorConfig = Message<"dockyaml.v1.EditorConfig"> & {
+  /**
+   * allow scrolling until the last line reaches the top of the view,
+   * for files taller than the viewport (classic Monaco behavior)
+   *
+   * @generated from field: bool scrollPastEnd = 1;
+   */
+  scrollPastEnd: boolean;
+};
+
+/**
+ * Describes the message dockyaml.v1.EditorConfig.
+ * Use `create(EditorConfigSchema)` to create a new message.
+ */
+export const EditorConfigSchema: GenMessage<EditorConfig> = /*@__PURE__*/
+  messageDesc(file_dockyaml_v1_dockyaml, 7);
 
 /**
  * @generated from message dockyaml.v1.VolumesConfig
@@ -174,7 +199,7 @@ export type VolumesConfig = Message<"dockyaml.v1.VolumesConfig"> & {
  * Use `create(VolumesConfigSchema)` to create a new message.
  */
 export const VolumesConfigSchema: GenMessage<VolumesConfig> = /*@__PURE__*/
-  messageDesc(file_dockyaml_v1_dockyaml, 7);
+  messageDesc(file_dockyaml_v1_dockyaml, 8);
 
 /**
  * @generated from message dockyaml.v1.NetworkConfig
@@ -191,7 +216,7 @@ export type NetworkConfig = Message<"dockyaml.v1.NetworkConfig"> & {
  * Use `create(NetworkConfigSchema)` to create a new message.
  */
 export const NetworkConfigSchema: GenMessage<NetworkConfig> = /*@__PURE__*/
-  messageDesc(file_dockyaml_v1_dockyaml, 8);
+  messageDesc(file_dockyaml_v1_dockyaml, 9);
 
 /**
  * @generated from message dockyaml.v1.ImageConfig
@@ -208,7 +233,7 @@ export type ImageConfig = Message<"dockyaml.v1.ImageConfig"> & {
  * Use `create(ImageConfigSchema)` to create a new message.
  */
 export const ImageConfigSchema: GenMessage<ImageConfig> = /*@__PURE__*/
-  messageDesc(file_dockyaml_v1_dockyaml, 9);
+  messageDesc(file_dockyaml_v1_dockyaml, 10);
 
 /**
  * @generated from message dockyaml.v1.ContainerConfig
@@ -225,7 +250,7 @@ export type ContainerConfig = Message<"dockyaml.v1.ContainerConfig"> & {
  * Use `create(ContainerConfigSchema)` to create a new message.
  */
 export const ContainerConfigSchema: GenMessage<ContainerConfig> = /*@__PURE__*/
-  messageDesc(file_dockyaml_v1_dockyaml, 10);
+  messageDesc(file_dockyaml_v1_dockyaml, 11);
 
 /**
  * @generated from message dockyaml.v1.Sort
@@ -247,7 +272,7 @@ export type Sort = Message<"dockyaml.v1.Sort"> & {
  * Use `create(SortSchema)` to create a new message.
  */
 export const SortSchema: GenMessage<Sort> = /*@__PURE__*/
-  messageDesc(file_dockyaml_v1_dockyaml, 11);
+  messageDesc(file_dockyaml_v1_dockyaml, 12);
 
 /**
  * @generated from service dockyaml.v1.DockyamlService

--- a/ui/src/pages/compose/components/editor-common.tsx
+++ b/ui/src/pages/compose/components/editor-common.tsx
@@ -97,7 +97,10 @@ function EditorCommon({filename, setFileSaveStatus, saveFile, getFile}: TextEdit
     }
 
     return (
-        <Box sx={{flexGrow: 1, position: 'relative'}}>
+        // clip Monaco overlays (e.g. the sticky scroll band, which keeps a
+        // stale width when the widget panel resizes the editor) so they can
+        // never paint over neighboring panels
+        <Box sx={{flexGrow: 1, position: 'relative', overflow: 'hidden'}}>
             <MonacoEditor
                 selectedFile={filename}
                 fileContent={contents}

--- a/ui/src/pages/compose/components/editor.tsx
+++ b/ui/src/pages/compose/components/editor.tsx
@@ -36,23 +36,25 @@ export function MonacoEditor(
     const {dockYaml} = useConfig()
     const scrollPastEnd = dockYaml?.editorPage?.scrollPastEnd ?? false
 
-    // dockman.yml editor.scrollPastEnd re-enables Monaco's scroll-beyond-last-line,
-    // but only while the file is taller than the viewport: short files never
-    // scroll past their end, long files can bring the last line to the top
+    // dockman.yml editor.scrollPastEnd lets long files scroll half a viewport
+    // past their end (the last line stops at mid-view, not at the top), via a
+    // bottom padding applied only while the file is taller than the viewport:
+    // short files never scroll past their end
     useEffect(() => {
         const editor = editorRef.current;
         if (!editor) return;
 
         if (!scrollPastEnd) {
-            editor.updateOptions({scrollBeyondLastLine: false});
+            editor.updateOptions({padding: {bottom: 0}});
             return;
         }
 
         const apply = () => {
             const lineHeight = editor.getOption(monacoEditor.editor.EditorOption.lineHeight);
             const lineCount = editor.getModel()?.getLineCount() ?? 0;
-            const overflows = lineCount * lineHeight > editor.getLayoutInfo().height;
-            editor.updateOptions({scrollBeyondLastLine: overflows});
+            const height = editor.getLayoutInfo().height;
+            const overflows = lineCount * lineHeight > height;
+            editor.updateOptions({padding: {bottom: overflows ? Math.round(height / 2) : 0}});
         };
 
         apply();

--- a/ui/src/pages/compose/components/editor.tsx
+++ b/ui/src/pages/compose/components/editor.tsx
@@ -121,6 +121,10 @@ export function MonacoEditor(
                 selectOnLineNumbers: true,
                 minimap: {enabled: false},
                 automaticLayout: true,
+                // stop the view from scrolling past the last line: short files
+                // no longer show a useless scrollbar and long files stop with
+                // the last line at the bottom, like classic editors
+                scrollBeyondLastLine: false,
             }}
         />
     );

--- a/ui/src/pages/compose/components/editor.tsx
+++ b/ui/src/pages/compose/components/editor.tsx
@@ -6,6 +6,7 @@ import {callRPC, useHostClient} from "../../../lib/api.ts";
 import {useSnackbar} from "../../../hooks/snackbar.ts";
 import {useTabs, useTabsStore} from "../../../context/tab-context.tsx";
 import {FileService} from "../../../gen/files/v1/files_pb.ts";
+import {useConfig} from "../../../hooks/config.ts";
 
 interface MonacoEditorProps {
     selectedFile: string;
@@ -27,6 +28,38 @@ export function MonacoEditor(
 
     const [mounted, setMounted] = useState(false);
     const {setTabDetails} = useTabs()
+
+    const {dockYaml} = useConfig()
+    const scrollPastEnd = dockYaml?.editorPage?.scrollPastEnd ?? false
+
+    // dockman.yml editor.scrollPastEnd re-enables Monaco's scroll-beyond-last-line,
+    // but only while the file is taller than the viewport: short files never
+    // scroll past their end, long files can bring the last line to the top
+    useEffect(() => {
+        if (!mounted) return;
+        const editor = editorRef.current;
+        if (!editor) return;
+
+        if (!scrollPastEnd) {
+            editor.updateOptions({scrollBeyondLastLine: false});
+            return;
+        }
+
+        const apply = () => {
+            const lineHeight = editor.getOption(monacoEditor.editor.EditorOption.lineHeight);
+            const lineCount = editor.getModel()?.getLineCount() ?? 0;
+            const overflows = lineCount * lineHeight > editor.getLayoutInfo().height;
+            editor.updateOptions({scrollBeyondLastLine: overflows});
+        };
+
+        apply();
+        const contentSub = editor.onDidChangeModelContent(apply);
+        const layoutSub = editor.onDidLayoutChange(apply);
+        return () => {
+            contentSub.dispose();
+            layoutSub.dispose();
+        };
+    }, [scrollPastEnd, mounted]);
 
     const handleEditorDidMount = (editor: monacoEditor.editor.IStandaloneCodeEditor, monaco: Monaco) => {
         editorRef.current = editor;
@@ -124,7 +157,11 @@ export function MonacoEditor(
                 // stop the view from scrolling past the last line: short files
                 // no longer show a useless scrollbar and long files stop with
                 // the last line at the bottom, like classic editors
+                // (dockman.yml editor.scrollPastEnd re-enables it dynamically)
                 scrollBeyondLastLine: false,
+                // hover/suggest widgets render position:fixed so the overflow
+                // clip on the editor container cannot cut them off
+                fixedOverflowWidgets: true,
             }}
         />
     );

--- a/ui/src/pages/compose/components/editor.tsx
+++ b/ui/src/pages/compose/components/editor.tsx
@@ -27,6 +27,10 @@ export function MonacoEditor(
     const saveLineNum = useSaveLineNum()
 
     const [mounted, setMounted] = useState(false);
+    // bumped on every editor instance creation: the component remounts per
+    // file (key={selectedFile}) while `mounted` stays true, so effects that
+    // must re-attach to the new instance depend on this counter instead
+    const [editorGen, setEditorGen] = useState(0);
     const {setTabDetails} = useTabs()
 
     const {dockYaml} = useConfig()
@@ -36,7 +40,6 @@ export function MonacoEditor(
     // but only while the file is taller than the viewport: short files never
     // scroll past their end, long files can bring the last line to the top
     useEffect(() => {
-        if (!mounted) return;
         const editor = editorRef.current;
         if (!editor) return;
 
@@ -59,11 +62,12 @@ export function MonacoEditor(
             contentSub.dispose();
             layoutSub.dispose();
         };
-    }, [scrollPastEnd, mounted]);
+    }, [scrollPastEnd, editorGen]);
 
     const handleEditorDidMount = (editor: monacoEditor.editor.IStandaloneCodeEditor, monaco: Monaco) => {
         editorRef.current = editor;
         setMounted(true);
+        setEditorGen(gen => gen + 1);
         editor.focus();
 
         editor.addCommand(

--- a/ui/src/pages/compose/tab-editor.tsx
+++ b/ui/src/pages/compose/tab-editor.tsx
@@ -222,7 +222,7 @@ const SidebarContent = (
         activeAction: string | null;
         actions: Record<string, ActionItem>
     }) => {
-    const {panelSize, panelRef, handleMouseDown, isResizing} = useResizeBar('left', 450)
+    const {panelSize, panelRef, handleMouseDown, isResizing} = useResizeBar('left', 280)
 
     return (
         <Box ref={panelRef}


### PR DESCRIPTION
## What

A set of fixes on the editor view scrolling and layout:

1. **Stop scrolling past the last line** — Monaco's default `scrollBeyondLastLine` lets the view scroll until the last line sits alone at the top: short files that fit on screen still get a scrollbar and can be scrolled almost fully out of view. Disabled — the scroll range now ends with the last line at the bottom, like classic editors, and files that fit don't scroll at all.

2. **Opt-in `editor.scrollPastEnd`** in `dockman.yml` for people who like some overshoot:

   ```yaml
   editor:
     scrollPastEnd: true
   ```

   Instead of the full scroll-to-top, it adds **half a viewport** of bottom padding, so the last line stops at mid-view (on a 50-line view, a 150-line file scrolls until the last 25 lines remain visible). Applied dynamically only while the file is taller than the viewport — short files never scroll past their end. New `EditorConfig.editorPage` proto message (regenerated stubs included).

3. **Sticky scroll band contained to the editor** — the sticky scroll widget keeps a stale (full) width when the editor shrinks, e.g. when a right-toolbar widget panel (deploy, it-tools) opens, and painted on top of that panel. Monaco overlays are now clipped to the editor container; hover/suggest widgets switch to `fixedOverflowWidgets` so the clip cannot cut them off.

4. **Narrower widget panel default** — the right-toolbar widget panel opened at 450px, close to half the editor on a laptop-sized window. It now opens at 280px, which comfortably fits the widest widget content (the deploy button grid), and stays resizable (150–600px).
