### PR TITLE
fix(images): report unused images from real container references

### DIFF
--- a/core/internal/docker/container/image.go
+++ b/core/internal/docker/container/image.go
@@ -70,12 +70,53 @@ func (s *Service) ImageDelete(ctx context.Context, imageId string) ([]image.Dele
 	return remove.Items, err
 }
 
+// ImageUsageCounts returns, per image ID, how many containers (running or
+// stopped) were created from it. The image list's own Containers field is
+// unreliable (-1 when not computed, 0 on some image stores), while image
+// prune decides from the daemon's actual reference counts — so usage comes
+// from the disk-usage report (the daemon-computed count) complemented by the
+// container list, and matches what prune would really do.
+func (s *Service) ImageUsageCounts(ctx context.Context) (map[string]int64, error) {
+	counts := make(map[string]int64)
+
+	diskUsage, err := s.Client.DiskUsage(ctx, client.DiskUsageOptions{
+		Images:  true,
+		Verbose: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get disk usage data: %w", err)
+	}
+	for _, img := range diskUsage.Images.Items {
+		if img.Containers > 0 {
+			counts[img.ID] = img.Containers
+		}
+	}
+
+	// an image missing from disk usage (or reported without a computed count)
+	// must still show as used while a container references it
+	resp, err := s.Client.ContainerList(ctx, client.ContainerListOptions{All: true})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list containers: %w", err)
+	}
+	perID := make(map[string]int64, len(resp.Items))
+	for _, c := range resp.Items {
+		perID[c.ImageID]++
+	}
+	for id, n := range perID {
+		if n > counts[id] {
+			counts[id] = n
+		}
+	}
+
+	return counts, nil
+}
+
 func (s *Service) ImagePruneUntagged(ctx context.Context) (image.PruneReport, error) {
 	filter := client.Filters{}
 	// removes dangling (untagged) mostly due to image being updated
 	filter.Add("dangling", "true")
 
-	prune, err := s.Client.ImagePrune(ctx, client.ImagePruneOptions{})
+	prune, err := s.Client.ImagePrune(ctx, client.ImagePruneOptions{Filters: filter})
 	if err != nil {
 		return prune.Report, err
 	}

--- a/core/internal/docker/container/image.go
+++ b/core/internal/docker/container/image.go
@@ -111,6 +111,25 @@ func (s *Service) ImageUsageCounts(ctx context.Context) (map[string]int64, error
 	return counts, nil
 }
 
+// ImageDescendantContainers reports how many containers were created from the
+// image or from any image built on top of it, via the daemon's "ancestor"
+// filter. This catches base/parent images with no direct container: prune
+// keeps them because a dependent child image is still in use, so they must
+// not be reported as unused.
+func (s *Service) ImageDescendantContainers(ctx context.Context, imageID string) (int64, error) {
+	filters := client.Filters{}
+	filters.Add("ancestor", imageID)
+
+	resp, err := s.Client.ContainerList(ctx, client.ContainerListOptions{
+		All:     true,
+		Filters: filters,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to list containers for image %s: %w", imageID, err)
+	}
+	return int64(len(resp.Items)), nil
+}
+
 func (s *Service) ImagePruneUntagged(ctx context.Context) (image.PruneReport, error) {
 	filter := client.Filters{}
 	// removes dangling (untagged) mostly due to image being updated

--- a/core/internal/docker/handler_images.go
+++ b/core/internal/docker/handler_images.go
@@ -35,6 +35,13 @@ func (h *Handler) ImageList(ctx context.Context, req *connect.Request[v1.ListIma
 	//	return nil, err
 	//}
 
+	// usage comes from the container list rather than the summary's
+	// Containers field, so the unused count matches what prune would do
+	usage, err := dkSrv.Container.ImageUsageCounts(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	var unusedContainers int64
 	var totalDisk int64
 	var untagged int64
@@ -47,12 +54,13 @@ func (h *Handler) ImageList(ctx context.Context, req *connect.Request[v1.ListIma
 			untagged++
 		}
 
-		if img.Containers == 0 {
+		containers := usage[img.ID]
+		if containers == 0 {
 			unusedContainers++
 		}
 
 		rpcImages = append(rpcImages, &v1.Image{
-			Containers:  img.Containers,
+			Containers:  containers,
 			Created:     img.Created,
 			Id:          img.ID,
 			Labels:      img.Labels,

--- a/core/internal/docker/handler_images.go
+++ b/core/internal/docker/handler_images.go
@@ -56,6 +56,15 @@ func (h *Handler) ImageList(ctx context.Context, req *connect.Request[v1.ListIma
 
 		containers := usage[img.ID]
 		if containers == 0 {
+			// no direct container: the image may still be the base of an
+			// image whose containers run — prune keeps those, so they must
+			// count as used too
+			containers, err = dkSrv.Container.ImageDescendantContainers(ctx, img.ID)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if containers == 0 {
 			unusedContainers++
 		}
 


### PR DESCRIPTION
## What

Fixes the "Prune Unused" badge reporting images as unused while every image is actually needed (and pruning consequently removing nothing).

## Why

Two layers to this bug:

1. The badge counted images whose `image.Summary.Containers` field was exactly `0`, but that field is unreliable: `-1` when the daemon did not compute it, and `0` on some image stores even while containers reference the image.

2. Even with an accurate direct count, an image with **no container of its own can still be the base of an image whose containers run**. `image prune` keeps those (dependent child images), yet they were reported as prunable — a host where every image is needed could show `Prune Unused (5)` while pruning removes nothing.

## How

Usage is now resolved in three tiers, all daemon-authoritative:

1. the **disk-usage report** — the same reference count prune honors;
2. the **container list** (`ImageID`) — so an image missing from disk usage still shows as used while a container references it;
3. for images with zero direct usage, the **`ancestor` container filter** — containers created from the image *or any image built on top of it* — which is exactly the dependency prune refuses to delete. The extra lookup only runs for images with no direct reference.

The per-image `USAGE` chip and the unused badge now match what prune would really delete.

Also fixed in passing: `ImagePruneUntagged` built a `dangling=true` filter but never passed it to `ImagePrune` — it only worked because the daemon defaults to pruning dangling images.

## Testing

- On a host where every image is referenced directly (containers) or indirectly (base of an in-use image): badge shows `Prune Unused (0)`.
- Images with no direct or descendant container are counted, and pruning removes them as announced.
