### PR TITLE
fix(images): searching no longer crashes the page on untagged images

### DIFF
--- a/ui/src/pages/images/images.tsx
+++ b/ui/src/pages/images/images.tsx
@@ -26,10 +26,13 @@ const ImagesPage = () => {
 
     const filteredImages = useMemo(() => {
         if (search) {
+            // untagged (dangling) images have no repoTags at all — indexing
+            // [0] blindly crashed the whole page on the first keystroke.
+            // Match any tag or the id, case-insensitively.
+            const query = search.toLowerCase();
             return images.filter(image =>
-                image.repoTags[0]
-                    .toLowerCase()
-                    .includes(search))
+                image.repoTags.some(tag => tag.toLowerCase().includes(query)) ||
+                image.id.toLowerCase().includes(query))
         }
         return images;
     }, [images, search]);


### PR DESCRIPTION
# fix(images): searching no longer crashes the page on untagged images

## Why

Typing anything into the Images view's search box while an untagged (dangling) image exists blanks the whole page:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'toLowerCase')
    at Array.filter (<anonymous>)
```

The filter indexes `image.repoTags[0]` blindly — dangling images have an empty `repoTags`, so the first keystroke throws inside `Array.filter` and React unmounts the tree.

## What changed

The filter now matches **any** of the image's tags **or its id**, and lowercases the query:

```ts
const query = search.toLowerCase();
return images.filter(image =>
    image.repoTags.some(tag => tag.toLowerCase().includes(query)) ||
    image.id.toLowerCase().includes(query))
```

Side effects: the search becomes case-insensitive (it compared lowercased tags against the raw query before) and untagged images stay findable by id.

## Testing

Reproduced the exact crash with a `repoTags: []` fixture against the old expression, then verified the new filter: case-insensitive tag match, multi-tag match, id match, empty result without crash. Verified live on a deployment with dangling images present.
