### PR TITLE
feat(ui): optional auto-save with manual save, Ctrl+S and unsaved-changes indicator

### DIFF
--- a/ui/src/pages/compose/components/editor-common.tsx
+++ b/ui/src/pages/compose/components/editor-common.tsx
@@ -4,6 +4,7 @@ import {useSnackbar} from "../../../hooks/snackbar.ts";
 import {Alert, AlertTitle, Box, Button, CircularProgress, Link, Typography} from '@mui/material';
 import {ErrorOutline, WarningAmber} from '@mui/icons-material';
 import {type SaveState, useSaveStatus} from "../hooks/status-hook.tsx";
+import {useEditorSave} from "../state/save.ts";
 import {ErrFileNotSupported} from "../../../context/file-context.tsx";
 
 interface TextEditorProps {
@@ -22,7 +23,9 @@ function EditorCommon({filename, setFileSaveStatus, saveFile, getFile}: TextEdit
     const [loading, setLoading] = useState(true);
     const [err, setErr] = useState("");
 
-    const {status, handleContentChange} = useSaveStatus(500, filename);
+    const {status, handleContentChange, saveNow} = useSaveStatus(500, filename);
+    const registerSaver = useEditorSave(state => state.registerSaver);
+    const unregisterSaver = useEditorSave(state => state.unregisterSaver);
 
     const refreshFile = async () => {
         await getFile(filename)
@@ -59,6 +62,38 @@ function EditorCommon({filename, setFileSaveStatus, saveFile, getFile}: TextEdit
     useEffect(() => {
         loadFile().then();
     }, []);
+
+    // expose the manual save so toolbar buttons (diskette) can trigger it
+    useEffect(() => {
+        registerSaver(filename, saveNow);
+        return () => unregisterSaver(filename);
+    }, [filename, saveNow, registerSaver, unregisterSaver]);
+
+    // CTRL+S / CMD+S saves pending changes, even when auto-save is enabled
+    // (flushes the debounce immediately)
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if ((e.ctrlKey || e.metaKey) && !e.altKey && e.key.toLowerCase() === 's') {
+                e.preventDefault();
+                if (!e.repeat) {
+                    saveNow().then();
+                }
+            }
+        };
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [saveNow]);
+
+    // warn before closing the browser tab with unsaved changes
+    useEffect(() => {
+        const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+            if (useEditorSave.getState().dirtyFiles[filename]) {
+                e.preventDefault();
+            }
+        };
+        window.addEventListener('beforeunload', handleBeforeUnload);
+        return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+    }, [filename]);
 
     const onContentChange = (value: string | undefined) => {
         if (!value) return;

--- a/ui/src/pages/compose/components/editor-common.tsx
+++ b/ui/src/pages/compose/components/editor-common.tsx
@@ -36,7 +36,7 @@ function EditorCommon({filename, setFileSaveStatus, saveFile, getFile}: TextEdit
         }
     }, [filename, saveFile, showError]);
 
-    const {status, handleContentChange, saveNow} = useSaveStatus(500, filename, saveContents);
+    const {status, handleContentChange, saveNow, setBaseline} = useSaveStatus(500, filename, saveContents);
 
     const refreshFile = async () => {
         await getFile(filename)
@@ -47,6 +47,12 @@ function EditorCommon({filename, setFileSaveStatus, saveFile, getFile}: TextEdit
         setLoading(true)
 
         const {contents, err} = await getFile(filename)
+
+        if (!err) {
+            // the on-disk content is the baseline used to decide whether the
+            // file has unsaved changes (reverting edits clears "unsaved")
+            setBaseline(contents)
+        }
 
         // prefer an in-memory draft (unsaved edits from before a tab switch)
         // over the persisted content coming from the backend

--- a/ui/src/pages/compose/components/editor-common.tsx
+++ b/ui/src/pages/compose/components/editor-common.tsx
@@ -1,5 +1,5 @@
 import {MonacoEditor} from "./editor.tsx";
-import {useEffect, useState} from "react";
+import {useCallback, useEffect, useState} from "react";
 import {useSnackbar} from "../../../hooks/snackbar.ts";
 import {Alert, AlertTitle, Box, Button, CircularProgress, Link, Typography} from '@mui/material';
 import {ErrorOutline, WarningAmber} from '@mui/icons-material';
@@ -23,9 +23,20 @@ function EditorCommon({filename, setFileSaveStatus, saveFile, getFile}: TextEdit
     const [loading, setLoading] = useState(true);
     const [err, setErr] = useState("");
 
-    const {status, handleContentChange, saveNow} = useSaveStatus(500, filename);
     const registerSaver = useEditorSave(state => state.registerSaver);
     const unregisterSaver = useEditorSave(state => state.unregisterSaver);
+
+    const saveContents = useCallback(async (newContent: string): Promise<SaveState> => {
+        const err = await saveFile(filename, newContent);
+        if (err) {
+            showError(`Could not save contents: ${err}`);
+            return 'error'
+        } else {
+            return 'success'
+        }
+    }, [filename, saveFile, showError]);
+
+    const {status, handleContentChange, saveNow} = useSaveStatus(500, filename, saveContents);
 
     const refreshFile = async () => {
         await getFile(filename)
@@ -36,23 +47,19 @@ function EditorCommon({filename, setFileSaveStatus, saveFile, getFile}: TextEdit
         setLoading(true)
 
         const {contents, err} = await getFile(filename)
-        if (err) {
+
+        // prefer an in-memory draft (unsaved edits from before a tab switch)
+        // over the persisted content coming from the backend
+        const draft = useEditorSave.getState().drafts[filename];
+        if (draft !== undefined) {
+            setContents(draft)
+        } else if (err) {
             setErr(err)
         } else {
             setContents(contents)
         }
 
         setLoading(false);
-    };
-
-    const saveContents = async (newContent: string): Promise<SaveState> => {
-        const err = await saveFile(filename, newContent);
-        if (err) {
-            showError(`Could not save contents: ${err}`);
-            return 'error'
-        } else {
-            return 'success'
-        }
     };
 
     useEffect(() => {
@@ -96,8 +103,8 @@ function EditorCommon({filename, setFileSaveStatus, saveFile, getFile}: TextEdit
     }, [filename]);
 
     const onContentChange = (value: string | undefined) => {
-        if (!value) return;
-        handleContentChange(value, saveContents)
+        if (value === undefined) return;
+        handleContentChange(value)
     }
 
     if (loading) {

--- a/ui/src/pages/compose/components/editor-common.tsx
+++ b/ui/src/pages/compose/components/editor-common.tsx
@@ -68,7 +68,9 @@ function EditorCommon({filename, setFileSaveStatus, saveFile, getFile}: TextEdit
 
     useEffect(() => {
         loadFile().then();
-    }, []);
+        // reload content when switching to a different file
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [filename]);
 
     // expose the manual save so toolbar buttons (diskette) can trigger it
     useEffect(() => {

--- a/ui/src/pages/compose/components/editor.tsx
+++ b/ui/src/pages/compose/components/editor.tsx
@@ -1,10 +1,10 @@
 import {Editor, type Monaco} from "@monaco-editor/react";
 import {getLanguageFromExtension} from "../../../lib/editor";
-import {useCallback, useEffect, useRef, useState} from "react";
+import {useCallback, useEffect, useRef} from "react";
 import * as monacoEditor from "monaco-editor";
 import {callRPC, useHostClient} from "../../../lib/api.ts";
 import {useSnackbar} from "../../../hooks/snackbar.ts";
-import {useTabs, useTabsStore} from "../../../context/tab-context.tsx";
+import {getContextKey, useTabs, useTabsStore} from "../../../context/tab-context.tsx";
 import {FileService} from "../../../gen/files/v1/files_pb.ts";
 
 interface MonacoEditorProps {
@@ -24,19 +24,48 @@ export function MonacoEditor(
 
     const editorRef = useRef<monacoEditor.editor.IStandaloneCodeEditor | null>(null);
     const saveLineNum = useSaveLineNum()
-
-    const [mounted, setMounted] = useState(false);
     const {setTabDetails} = useTabs()
+
+    // keep the active filename in a ref: listeners are attached once on mount
+    // and mount does NOT re-run when the editor swaps to another file's model
+    const selectedFileRef = useRef(selectedFile);
+    selectedFileRef.current = selectedFile;
+
+    // Each file gets its own monaco model, unique per host/alias context.
+    // Combined with keepCurrentModel this makes undo/redo history and unsaved
+    // content survive switching between tabs (until a full page reload).
+    const modelPath = `${getContextKey()}/${selectedFile}`;
+
+    const restoreCaret = useCallback((editor: monacoEditor.editor.IStandaloneCodeEditor) => {
+        const model = editor.getModel();
+        if (!model) return;
+
+        const tab = useTabsStore.getState().allTabs[selectedFileRef.current];
+        if (!tab) return;
+        const {row, col} = tab;
+
+        // Clamp row/column to model size
+        const lineNumber = Math.min(row, model.getLineCount());
+        const column = Math.min(col, model.getLineMaxColumn(lineNumber));
+
+        editor.setPosition({lineNumber, column});
+        const padding = 5;
+        editor.revealRangeInCenter({
+            startLineNumber: Math.max(1, lineNumber - padding),
+            startColumn: 1,
+            endLineNumber: lineNumber + padding,
+            endColumn: 1,
+        });
+    }, []);
 
     const handleEditorDidMount = (editor: monacoEditor.editor.IStandaloneCodeEditor, monaco: Monaco) => {
         editorRef.current = editor;
-        setMounted(true);
         editor.focus();
 
         editor.addCommand(
             monaco.KeyMod.Alt | monaco.KeyCode.KeyL,
             async () => {
-                const {val, err} = await callRPC(() => file.format({filename: selectedFile}))
+                const {val, err} = await callRPC(() => file.format({filename: selectedFileRef.current}))
                 if (err) {
                     showError(err)
                 } else {
@@ -64,59 +93,31 @@ export function MonacoEditor(
             }
         );
 
-        editorRef.current?.getValue();
-
         editor.onDidChangeCursorPosition((e) => {
             const {lineNumber, column} = e.position;
-            saveLineNum({filename: selectedFile, col: column, row: lineNumber}, (value) => {
+            saveLineNum({filename: selectedFileRef.current, col: column, row: lineNumber}, (value) => {
                 setTabDetails(value.filename, {row: value.row, col: value.col});
             });
         });
+
+        restoreCaret(editor);
     };
 
+    // when the active file changes the editor swaps to that file's kept model;
+    // restore the caret for the newly-activated file
     useEffect(() => {
-        if (!mounted || !editorRef.current) return;
-
-        const model = editorRef.current.getModel();
-        if (!model) return;
-
-        // console.log("clearing stack for initial load");
-        model.pushStackElement();
-        model.setValue(fileContent);
-
-        const contentListener = model.onDidChangeContent(() => {
-            handleEditorChange(model.getValue());
-        });
-        const disposeListener = () => contentListener.dispose();
-
-        const tab = useTabsStore.getState().allTabs[selectedFile];
-        if (!tab) return disposeListener;
-        const {row, col} = tab;
-
-        // Clamp row/column to model size
-        const lineNumber = Math.min(row, model.getLineCount());
-        const column = Math.min(col, model.getLineMaxColumn(lineNumber));
-
-        editorRef.current.setPosition({lineNumber, column});
-        const padding = 5;
-        editorRef.current.revealRangeInCenter({
-            startLineNumber: Math.max(1, lineNumber - padding),
-            startColumn: 1,
-            endLineNumber: lineNumber + padding,
-            endColumn: 1,
-        });
-        // do not add tabs as dependencies
-        // it will mess with the editor typing
-        // resetting cursor position when the tab
-        return disposeListener;
-    }, [fileContent, selectedFile, mounted]);
+        const editor = editorRef.current;
+        if (editor) restoreCaret(editor);
+    }, [selectedFile, restoreCaret]);
 
     return (
         <Editor
-            key={selectedFile}
-            language={getLanguageFromExtension(selectedFile)}
-            defaultValue={""}
+            path={modelPath}
+            keepCurrentModel
+            defaultLanguage={getLanguageFromExtension(selectedFile)}
+            defaultValue={fileContent}
             onMount={handleEditorDidMount}
+            onChange={handleEditorChange}
             theme="vs-dark"
             options={{
                 tabSize: 2,

--- a/ui/src/pages/compose/components/editor.tsx
+++ b/ui/src/pages/compose/components/editor.tsx
@@ -84,12 +84,13 @@ export function MonacoEditor(
         model.pushStackElement();
         model.setValue(fileContent);
 
-        model.onDidChangeContent(() => {
+        const contentListener = model.onDidChangeContent(() => {
             handleEditorChange(model.getValue());
         });
+        const disposeListener = () => contentListener.dispose();
 
         const tab = useTabsStore.getState().allTabs[selectedFile];
-        if (!tab) return;
+        if (!tab) return disposeListener;
         const {row, col} = tab;
 
         // Clamp row/column to model size
@@ -107,6 +108,7 @@ export function MonacoEditor(
         // do not add tabs as dependencies
         // it will mess with the editor typing
         // resetting cursor position when the tab
+        return disposeListener;
     }, [fileContent, selectedFile, mounted]);
 
     return (

--- a/ui/src/pages/compose/components/file-item.tsx
+++ b/ui/src/pages/compose/components/file-item.tsx
@@ -24,6 +24,7 @@ import {useFileCreate} from "../dialogs/file-create.tsx";
 import {useFileDelete} from "../dialogs/file-delete.tsx";
 import {useFileRename} from "../dialogs/file-rename.tsx";
 import {useAliasStore, useHostStore, useOpenFiles} from "../state/files.ts";
+import {useEditorSave} from "../state/save.ts";
 import {useConfig} from "../../../hooks/config.ts";
 import {useComposeFileState} from "../state/status.ts";
 import {getContextKey} from "../../../context/tab-context.tsx";
@@ -136,6 +137,9 @@ const FolderItemDisplay = ({entry, depthIndex}: {
     // Highlight if we are currently editing the compose file this folder points to
     const isSelected = useIsSelected(composeFilePath);
 
+    // reflect unsaved edits of the compose file this folder points to
+    const isDirty = useEditorSave(state => state.dirtyFiles[entry.isComposeFolder] ?? false);
+
     const closeComposeStatus = useComposeFileState(state => state.delete)
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -222,7 +226,8 @@ const FolderItemDisplay = ({entry, depthIndex}: {
                     textDecoration: 'none'
                 }}
             >
-                <ListItemIcon sx={{minWidth: 32}}>
+                <ListItemIcon sx={{minWidth: 32, position: 'relative'}}>
+                    {isComposeFolder && <UnsavedDot dirty={isDirty}/>}
                     {isComposeFolder ?
                         <DockerFolderIcon/> :
                         <Folder sx={{color: amber[800], fontSize: '1.1rem'}}/>
@@ -330,6 +335,7 @@ const FileItemDisplay = ({entry}: { entry: FsEntry }) => {
 
     const isSelected = useIsSelected(filePath);
     const displayName = getEntryDisplayName(filename);
+    const isDirty = useEditorSave(state => state.dirtyFiles[filename] ?? false);
 
     const {contextMenu, closeCtxMenu, contextActions, handleContextMenu} = useFileMenuCtx(entry)
 
@@ -347,7 +353,8 @@ const FileItemDisplay = ({entry}: { entry: FsEntry }) => {
                 to={filePath}
                 component={RouterLink}
             >
-                <ListItemIcon sx={{minWidth: 32}}>
+                <ListItemIcon sx={{minWidth: 32, position: 'relative'}}>
+                    <UnsavedDot dirty={isDirty}/>
                     {<FileIcon filename={filename}/>}
                 </ListItemIcon>
 
@@ -496,6 +503,30 @@ const useFileMenuCtx = (entry: FsEntry) => {
 
     return {closeCtxMenu, contextActions, contextMenu, handleContextMenu}
 }
+
+// Amber dot shown on the LEFT of a file/compose-folder that has unsaved
+// edits. Kept visually distinct from the docker StatusIndicator (right side).
+const UnsavedDot = ({dirty}: { dirty: boolean }) => {
+    if (!dirty) return null;
+    return (
+        <Tooltip title="Unsaved changes" arrow placement="right">
+            <Box
+                sx={{
+                    position: 'absolute',
+                    top: -1,
+                    left: -1,
+                    width: 9,
+                    height: 9,
+                    borderRadius: '50%',
+                    bgcolor: 'warning.main',
+                    border: '2px solid',
+                    borderColor: 'background.paper',
+                    zIndex: 1,
+                }}
+            />
+        </Tooltip>
+    );
+};
 
 const StatusIndicator = ({fileStatus}: { fileStatus: Status }) => {
     const stackStatus = getStatusTheme(fileStatus);

--- a/ui/src/pages/compose/components/viewer-dockyml.tsx
+++ b/ui/src/pages/compose/components/viewer-dockyml.tsx
@@ -1,6 +1,9 @@
 import {callRPC, useHostClient} from "../../../lib/api.ts";import {DockyamlService} from "../../../gen/dockyaml/v1/dockyaml_pb.ts";
 import {Box, Button, capitalize, Tooltip, Typography} from '@mui/material';
+import {SaveOutlined} from "@mui/icons-material";
 import {indicatorMap, type SaveState} from "../hooks/status-hook.tsx";
+import {useEditorSave} from "../state/save.ts";
+import {ShortcutFormatter} from "./shortcut-formatter.tsx";
 import {useConfig} from "../../../hooks/config.ts";
 import {useState} from "react";
 import EditorCommon from "./editor-common.tsx";
@@ -33,6 +36,9 @@ function DockyamlViewer({filename}: { filename: string }) {
     const {fetchDockmanYaml} = useConfig()
 
     const [saveStatus, setSaveStatus] = useState<SaveState>('idle')
+
+    const isDirty = useEditorSave(state => state.dirtyFiles[filename] ?? false)
+    const saveNow = useEditorSave(state => state.savers[filename])
 
     const refreshFile = async () => {
         await getFile()
@@ -99,6 +105,22 @@ function DockyamlViewer({filename}: { filename: string }) {
                         >
                             Apply
                         </Button>
+                    </Tooltip>
+
+                    <Tooltip title={<ShortcutFormatter title={"Save file"} keyCombo={["CTRL", "S"]}/>}>
+                        <span>
+                            <Button
+                                size="small"
+                                variant="outlined"
+                                color="success"
+                                disabled={!isDirty}
+                                onClick={() => saveNow?.()}
+                                startIcon={<SaveOutlined sx={{fontSize: 16}}/>}
+                                sx={{fontSize: '0.75rem', textTransform: 'none'}}
+                            >
+                                Save
+                            </Button>
+                        </span>
                     </Tooltip>
 
                     <Typography variant="caption" sx={{

--- a/ui/src/pages/compose/components/viewer-text.tsx
+++ b/ui/src/pages/compose/components/viewer-text.tsx
@@ -267,9 +267,17 @@ function ViewerTextEditor({filename, track}: { filename: string, track: number }
                             </span>
                         </Tooltip>
 
-                        <Tooltip title={autoSave ?
-                            "Auto-save is on: changes are saved as you type" :
-                            "Auto-save is off: save manually with the save button or CTRL + S"
+                        <Tooltip title={
+                            <Box sx={{maxWidth: 240}}>
+                                <Typography variant="caption" display="block">
+                                    {autoSave
+                                        ? "Auto-save is on: changes are saved as you type."
+                                        : "Auto-save is off: save manually with the save button or CTRL + S."}
+                                </Typography>
+                                <Typography variant="caption" display="block" sx={{mt: 0.5, opacity: 0.8}}>
+                                    Unsaved changes are kept when switching tabs, but are lost if you fully reload the page.
+                                </Typography>
+                            </Box>
                         }>
                             <FormControlLabel
                                 control={

--- a/ui/src/pages/compose/components/viewer-text.tsx
+++ b/ui/src/pages/compose/components/viewer-text.tsx
@@ -1,6 +1,18 @@
 import React, {type ReactElement, useEffect, useMemo, useState} from 'react';
 import {useNavigate, useSearchParams} from 'react-router-dom';
-import {Box, Button, CircularProgress, Fade, Tab, Tabs, Tooltip} from '@mui/material';
+import {
+    Box,
+    Button,
+    CircularProgress,
+    Fade,
+    FormControlLabel,
+    IconButton,
+    Switch,
+    Tab,
+    Tabs,
+    Tooltip,
+    Typography
+} from '@mui/material';
 import {useFileComponents} from "../state/terminal.tsx";
 import {callRPC, useHostClient} from "../../../lib/api.ts";
 import {isComposeFile, useEditorUrl} from "../../../lib/editor.ts";
@@ -9,10 +21,11 @@ import {ShortcutFormatter} from "./shortcut-formatter.tsx";
 import {TabDeploy} from "../tab-deploy.tsx";
 import {TabStat} from "../tab-stats.tsx";
 import CenteredMessage from "../../../components/centered-message.tsx";
-import {ErrorOutline} from "@mui/icons-material";
+import {ErrorOutline, SaveOutlined} from "@mui/icons-material";
 import {useOpenFiles} from "../state/files.ts";
 import {FileService} from "../../../gen/files/v1/files_pb.ts";
 import {indicatorMap, type SaveState} from "../hooks/status-hook.tsx";
+import {useEditorSave} from "../state/save.ts";
 
 export enum TabType {
     // noinspection JSUnusedGlobalSymbols
@@ -107,6 +120,11 @@ function ViewerTextEditor({filename, track}: { filename: string, track: number }
     }, [filename, navigate]);
 
     const [saveStatus, setSaveStatus] = useState<SaveState>('idle')
+
+    const autoSave = useEditorSave(state => state.autoSave)
+    const toggleAutoSave = useEditorSave(state => state.toggleAutoSave)
+    const isDirty = useEditorSave(state => state.dirtyFiles[filename] ?? false)
+    const saveNow = useEditorSave(state => state.savers[filename])
 
 
     const tabsList: TabDetails[] = useMemo(() => {
@@ -223,7 +241,7 @@ function ViewerTextEditor({filename, track}: { filename: string, track: number }
                 </Tabs>
 
                 {selectedTab === TabType.EDITOR &&
-                    <Box sx={{display: 'flex', gap: 1, px: 2}}>
+                    <Box sx={{display: 'flex', alignItems: 'center', gap: 1, px: 2, ml: 'auto'}}>
                         {buttonList.map((details) => (
                             <Button
                                 size="small"
@@ -234,6 +252,41 @@ function ViewerTextEditor({filename, track}: { filename: string, track: number }
                                 {details.title}
                             </Button>
                         ))}
+
+                        <Tooltip title={<ShortcutFormatter title={"Save file"} keyCombo={["CTRL", "S"]}/>}>
+                            <span>
+                                <IconButton
+                                    size="small"
+                                    aria-label="Save file"
+                                    disabled={!isDirty}
+                                    color={isDirty ? "warning" : "default"}
+                                    onClick={() => saveNow?.()}
+                                >
+                                    <SaveOutlined/>
+                                </IconButton>
+                            </span>
+                        </Tooltip>
+
+                        <Tooltip title={autoSave ?
+                            "Auto-save is on: changes are saved as you type" :
+                            "Auto-save is off: save manually with the save button or CTRL + S"
+                        }>
+                            <FormControlLabel
+                                control={
+                                    <Switch
+                                        size="small"
+                                        checked={autoSave}
+                                        onChange={toggleAutoSave}
+                                    />
+                                }
+                                label={
+                                    <Typography variant="caption" color="text.secondary">
+                                        Auto-save
+                                    </Typography>
+                                }
+                                sx={{mr: 0, ml: 0, whiteSpace: 'nowrap'}}
+                            />
+                        </Tooltip>
                     </Box>
                 }
             </Box>

--- a/ui/src/pages/compose/hooks/status-hook.tsx
+++ b/ui/src/pages/compose/hooks/status-hook.tsx
@@ -1,7 +1,8 @@
 import {type ReactNode, useCallback, useEffect, useRef, useState} from "react";
 import {Typography} from "@mui/material";
+import {useEditorSave} from "../state/save.ts";
 
-export type SaveState = 'idle' | 'typing' | 'saving' | 'success' | 'error'
+export type SaveState = 'idle' | 'typing' | 'unsaved' | 'saving' | 'success' | 'error'
 
 
 export type OnSave = (value: string) => Promise<SaveState>
@@ -10,12 +11,17 @@ export type SaveCallback = (value: string, onSave: OnSave) => void
 interface UseSaveStatusReturn {
     status: SaveState;
     handleContentChange: SaveCallback;
+    saveNow: () => Promise<void>;
 }
 
 export const indicatorMap: Record<SaveState, { color: string, component: ReactNode }> = {
     typing: {
         color: "primary.main",
         component: <Typography variant="button" color="primary.main">Typing</Typography>
+    },
+    unsaved: {
+        color: "warning.main",
+        component: <Typography variant="button" color="warning.main">Unsaved</Typography>
     },
     saving: {
         color: "info.main",
@@ -37,31 +43,68 @@ export const indicatorMap: Record<SaveState, { color: string, component: ReactNo
 
 export function useSaveStatus(debounceMs: number = 500, filename: string): UseSaveStatusReturn {
     const [status, setStatus] = useState<SaveState>('idle');
-    const debounceTimeout = useRef<null | number>(null);
+    const debounceTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    // latest content that has not been persisted yet
+    const pendingValue = useRef<string | null>(null);
+    const pendingOnSave = useRef<OnSave | null>(null);
+
+    const autoSave = useEditorSave(state => state.autoSave);
+    const setDirty = useEditorSave(state => state.setDirty);
 
     useEffect(() => {
+        pendingValue.current = null;
+        pendingOnSave.current = null;
         setStatus('idle');
     }, [filename]);
 
+    const saveNow = useCallback(async () => {
+        if (debounceTimeout.current) {
+            clearTimeout(debounceTimeout.current);
+            debounceTimeout.current = null;
+        }
+
+        const value = pendingValue.current;
+        const onSave = pendingOnSave.current;
+        if (value === null || !onSave) return;
+
+        setStatus('saving');
+        const state = await onSave(value);
+        if (state === 'success') {
+            pendingValue.current = null;
+            setDirty(filename, false);
+        }
+        setStatus(state);
+    }, [filename, setDirty]);
+
     const handleContentChange = useCallback<SaveCallback>((value, onSave) => {
-        setStatus('typing');
+        pendingValue.current = value;
+        pendingOnSave.current = onSave;
+        setDirty(filename, true);
 
         if (debounceTimeout.current) {
             clearTimeout(debounceTimeout.current);
         }
 
-        // @ts-ignore TODO why is this err
-        debounceTimeout.current = setTimeout(async () => {
-            setStatus('saving');
-            const state = await onSave(value)
-            setStatus(state);
+        if (!autoSave) {
+            // manual mode: only mark the file as dirty,
+            // saving happens via the save button or CTRL+S
+            setStatus('unsaved');
+            return;
+        }
+
+        setStatus('typing');
+        debounceTimeout.current = setTimeout(() => {
+            saveNow().then();
         }, debounceMs);
-    }, [debounceMs]);
+    }, [debounceMs, autoSave, filename, saveNow, setDirty]);
 
     useEffect(() => {
         if (status === 'success' || status === 'error') {
             const timer = setTimeout(() => {
-                setStatus('idle');
+                // if a save failed (or new edits arrived) there are still
+                // pending changes, fall back to 'unsaved' instead of 'idle'
+                setStatus(pendingValue.current !== null ? 'unsaved' : 'idle');
             }, 2000);
             return () => clearTimeout(timer);
         }
@@ -69,6 +112,7 @@ export function useSaveStatus(debounceMs: number = 500, filename: string): UseSa
 
     return {
         status,
-        handleContentChange
+        handleContentChange,
+        saveNow,
     };
 }

--- a/ui/src/pages/compose/hooks/status-hook.tsx
+++ b/ui/src/pages/compose/hooks/status-hook.tsx
@@ -6,7 +6,7 @@ export type SaveState = 'idle' | 'typing' | 'unsaved' | 'saving' | 'success' | '
 
 
 export type OnSave = (value: string) => Promise<SaveState>
-export type SaveCallback = (value: string, onSave: OnSave) => void
+export type SaveCallback = (value: string) => void
 
 interface UseSaveStatusReturn {
     status: SaveState;
@@ -41,21 +41,35 @@ export const indicatorMap: Record<SaveState, { color: string, component: ReactNo
     }
 };
 
-export function useSaveStatus(debounceMs: number = 500, filename: string): UseSaveStatusReturn {
+export function useSaveStatus(debounceMs: number, filename: string, onSave: OnSave): UseSaveStatusReturn {
     const [status, setStatus] = useState<SaveState>('idle');
     const debounceTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     // latest content that has not been persisted yet
     const pendingValue = useRef<string | null>(null);
-    const pendingOnSave = useRef<OnSave | null>(null);
+    // keep the save callback in a ref so saveNow() is stable and can flush
+    // a restored draft even before the user types anything
+    const onSaveRef = useRef(onSave);
+    useEffect(() => {
+        onSaveRef.current = onSave;
+    }, [onSave]);
 
     const autoSave = useEditorSave(state => state.autoSave);
     const setDirty = useEditorSave(state => state.setDirty);
+    const setDraft = useEditorSave(state => state.setDraft);
+    const clearDraft = useEditorSave(state => state.clearDraft);
 
+    // when switching to a file, restore any in-memory draft so unsaved edits
+    // survive tab switches; otherwise start clean
     useEffect(() => {
-        pendingValue.current = null;
-        pendingOnSave.current = null;
-        setStatus('idle');
+        const draft = useEditorSave.getState().drafts[filename];
+        if (draft !== undefined) {
+            pendingValue.current = draft;
+            setStatus('unsaved');
+        } else {
+            pendingValue.current = null;
+            setStatus('idle');
+        }
     }, [filename]);
 
     const saveNow = useCallback(async () => {
@@ -65,22 +79,22 @@ export function useSaveStatus(debounceMs: number = 500, filename: string): UseSa
         }
 
         const value = pendingValue.current;
-        const onSave = pendingOnSave.current;
-        if (value === null || !onSave) return;
+        if (value === null) return;
 
         setStatus('saving');
-        const state = await onSave(value);
+        const state = await onSaveRef.current(value);
         if (state === 'success') {
             pendingValue.current = null;
             setDirty(filename, false);
+            clearDraft(filename);
         }
         setStatus(state);
-    }, [filename, setDirty]);
+    }, [filename, setDirty, clearDraft]);
 
-    const handleContentChange = useCallback<SaveCallback>((value, onSave) => {
+    const handleContentChange = useCallback<SaveCallback>((value) => {
         pendingValue.current = value;
-        pendingOnSave.current = onSave;
         setDirty(filename, true);
+        setDraft(filename, value);
 
         if (debounceTimeout.current) {
             clearTimeout(debounceTimeout.current);
@@ -97,7 +111,7 @@ export function useSaveStatus(debounceMs: number = 500, filename: string): UseSa
         debounceTimeout.current = setTimeout(() => {
             saveNow().then();
         }, debounceMs);
-    }, [debounceMs, autoSave, filename, saveNow, setDirty]);
+    }, [debounceMs, autoSave, filename, saveNow, setDirty, setDraft]);
 
     useEffect(() => {
         if (status === 'success' || status === 'error') {

--- a/ui/src/pages/compose/hooks/status-hook.tsx
+++ b/ui/src/pages/compose/hooks/status-hook.tsx
@@ -12,6 +12,7 @@ interface UseSaveStatusReturn {
     status: SaveState;
     handleContentChange: SaveCallback;
     saveNow: () => Promise<void>;
+    setBaseline: (content: string) => void;
 }
 
 export const indicatorMap: Record<SaveState, { color: string, component: ReactNode }> = {
@@ -45,8 +46,11 @@ export function useSaveStatus(debounceMs: number, filename: string, onSave: OnSa
     const [status, setStatus] = useState<SaveState>('idle');
     const debounceTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-    // latest content that has not been persisted yet
+    // latest content that has not been persisted yet (null = nothing to save)
     const pendingValue = useRef<string | null>(null);
+    // the content currently on disk; a file is only "dirty" when the editor
+    // content differs from this. null means the baseline is not known yet.
+    const savedValue = useRef<string | null>(null);
     // keep the save callback in a ref so saveNow() is stable and can flush
     // a restored draft even before the user types anything
     const onSaveRef = useRef(onSave);
@@ -60,8 +64,10 @@ export function useSaveStatus(debounceMs: number, filename: string, onSave: OnSa
     const clearDraft = useEditorSave(state => state.clearDraft);
 
     // when switching to a file, restore any in-memory draft so unsaved edits
-    // survive tab switches; otherwise start clean
+    // survive tab switches; otherwise start clean. The baseline is unknown
+    // until the file finishes loading (see setBaseline).
     useEffect(() => {
+        savedValue.current = null;
         const draft = useEditorSave.getState().drafts[filename];
         if (draft !== undefined) {
             pendingValue.current = draft;
@@ -84,6 +90,7 @@ export function useSaveStatus(debounceMs: number, filename: string, onSave: OnSa
         setStatus('saving');
         const state = await onSaveRef.current(value);
         if (state === 'success') {
+            savedValue.current = value;
             pendingValue.current = null;
             setDirty(filename, false);
             clearDraft(filename);
@@ -91,14 +98,30 @@ export function useSaveStatus(debounceMs: number, filename: string, onSave: OnSa
         setStatus(state);
     }, [filename, setDirty, clearDraft]);
 
-    const handleContentChange = useCallback<SaveCallback>((value) => {
+    // compare the given content against the on-disk baseline and update the
+    // dirty flag / draft / status accordingly. Reverting all edits (e.g. via
+    // CTRL+Z) brings the content back to the baseline and clears "unsaved".
+    const reconcile = useCallback((value: string) => {
         pendingValue.current = value;
-        setDirty(filename, true);
-        setDraft(filename, value);
 
         if (debounceTimeout.current) {
             clearTimeout(debounceTimeout.current);
+            debounceTimeout.current = null;
         }
+
+        // if we don't know the baseline yet, treat any content as dirty
+        const dirty = savedValue.current === null || value !== savedValue.current;
+
+        if (!dirty) {
+            pendingValue.current = null;
+            setDirty(filename, false);
+            clearDraft(filename);
+            setStatus('idle');
+            return;
+        }
+
+        setDirty(filename, true);
+        setDraft(filename, value);
 
         if (!autoSave) {
             // manual mode: only mark the file as dirty,
@@ -111,7 +134,20 @@ export function useSaveStatus(debounceMs: number, filename: string, onSave: OnSa
         debounceTimeout.current = setTimeout(() => {
             saveNow().then();
         }, debounceMs);
-    }, [debounceMs, autoSave, filename, saveNow, setDirty, setDraft]);
+    }, [debounceMs, autoSave, filename, saveNow, setDirty, setDraft, clearDraft]);
+
+    const handleContentChange = useCallback<SaveCallback>((value) => {
+        reconcile(value);
+    }, [reconcile]);
+
+    // called by the editor once the on-disk content is loaded, so dirty state
+    // can be evaluated against it (also reconciles a restored draft)
+    const setBaseline = useCallback((content: string) => {
+        savedValue.current = content;
+        if (pendingValue.current !== null) {
+            reconcile(pendingValue.current);
+        }
+    }, [reconcile]);
 
     useEffect(() => {
         if (status === 'success' || status === 'error') {
@@ -128,5 +164,6 @@ export function useSaveStatus(debounceMs: number, filename: string, onSave: OnSa
         status,
         handleContentChange,
         saveNow,
+        setBaseline,
     };
 }

--- a/ui/src/pages/compose/state/save.ts
+++ b/ui/src/pages/compose/state/save.ts
@@ -1,0 +1,48 @@
+import {create} from 'zustand'
+import {persist} from 'zustand/middleware'
+
+interface EditorSaveState {
+    // when true, files are saved automatically as you type (legacy behaviour)
+    // when false, files must be saved explicitly (save button or CTRL+S)
+    autoSave: boolean
+    toggleAutoSave: () => void
+
+    // filename -> has changes that are not yet persisted
+    dirtyFiles: Record<string, boolean>
+    setDirty: (filename: string, dirty: boolean) => void
+
+    // filename -> callback that flushes pending changes to the backend
+    savers: Record<string, () => Promise<void>>
+    registerSaver: (filename: string, save: () => Promise<void>) => void
+    unregisterSaver: (filename: string) => void
+}
+
+export const useEditorSave = create<EditorSaveState>()(
+    persist(
+        (set) => ({
+            autoSave: true,
+            toggleAutoSave: () => set(state => ({autoSave: !state.autoSave})),
+
+            dirtyFiles: {},
+            setDirty: (filename, dirty) => set(state => ({
+                dirtyFiles: {...state.dirtyFiles, [filename]: dirty}
+            })),
+
+            savers: {},
+            registerSaver: (filename, save) => set(state => ({
+                savers: {...state.savers, [filename]: save}
+            })),
+            unregisterSaver: (filename) => set(state => {
+                const savers = {...state.savers}
+                delete savers[filename]
+                const dirtyFiles = {...state.dirtyFiles}
+                delete dirtyFiles[filename]
+                return {savers, dirtyFiles}
+            }),
+        }),
+        {
+            name: 'dockman-editor-save',
+            partialize: (state) => ({autoSave: state.autoSave}),
+        }
+    )
+)

--- a/ui/src/pages/compose/state/save.ts
+++ b/ui/src/pages/compose/state/save.ts
@@ -11,6 +11,12 @@ interface EditorSaveState {
     dirtyFiles: Record<string, boolean>
     setDirty: (filename: string, dirty: boolean) => void
 
+    // filename -> latest unsaved content, kept in memory so switching tabs
+    // does not discard edits that have not been written to disk yet
+    drafts: Record<string, string>
+    setDraft: (filename: string, content: string) => void
+    clearDraft: (filename: string) => void
+
     // filename -> callback that flushes pending changes to the backend
     savers: Record<string, () => Promise<void>>
     registerSaver: (filename: string, save: () => Promise<void>) => void
@@ -28,16 +34,27 @@ export const useEditorSave = create<EditorSaveState>()(
                 dirtyFiles: {...state.dirtyFiles, [filename]: dirty}
             })),
 
+            drafts: {},
+            setDraft: (filename, content) => set(state => ({
+                drafts: {...state.drafts, [filename]: content}
+            })),
+            clearDraft: (filename) => set(state => {
+                const drafts = {...state.drafts}
+                delete drafts[filename]
+                return {drafts}
+            }),
+
             savers: {},
             registerSaver: (filename, save) => set(state => ({
                 savers: {...state.savers, [filename]: save}
             })),
+            // only drop the save callback when the editor unmounts.
+            // dirty state and drafts are kept so the "unsaved" marker and the
+            // in-memory content survive switching between tabs.
             unregisterSaver: (filename) => set(state => {
                 const savers = {...state.savers}
                 delete savers[filename]
-                const dirtyFiles = {...state.dirtyFiles}
-                delete dirtyFiles[filename]
-                return {savers, dirtyFiles}
+                return {savers}
             }),
         }),
         {


### PR DESCRIPTION
Closes #226 

### What

Makes auto-save optional. Current auto-save-on-every-keystroke stays the default;
users can now switch to manual saving to avoid persisting half-finished edits.

### Changes

- **Auto-save toggle** in the editor toolbar, persisted in localStorage (default: on).
- **Manual save**: disk-icon button (enabled only when there are unsaved changes)
  and **Ctrl/Cmd+S** (also flushes the debounce when auto-save is on; prevents the
  browser save dialog).
- **Unsaved drafts survive tab switches**: edits are kept in memory per file and
  restored when returning to the tab.
- **Unsaved indicator**: amber dot on the left of the file in the tree, kept
  distinct from the existing docker status indicator on the right.
- **Undo/redo preserved across tab switches**: each file now uses its own Monaco
  model (`keepCurrentModel`) instead of recreating the editor + `setValue` on every
  switch. As a side effect this also fixed a listener leak where
  `onDidChangeContent` handlers were re-registered without disposal.
- Dirty state is tracked against the on-disk baseline, so reverting all edits
  (Ctrl+Z back to the original) correctly clears the "unsaved" state.

### Design notes / limitations

- Drafts are in-memory only: preserved across tab switches, **lost on a full page
  reload** (surfaced in the toggle's tooltip). Monaco has no public API to persist
  the undo stack, so this is by design.
- With `keepCurrentModel`, models are not disposed while the app is open ‚Äî memory
  grows slightly per opened file until reload. Negligible for this use case;
  disposing on tab-close could be a follow-up.
- Auto-save remains the default, so existing behaviour is unchanged unless the user
  opts out.

### How to test

1. **Auto-save on (default)**: edit a file ‚Üí it saves after the debounce; the amber
   dot appears then clears on save.
2. **Auto-save off**: edit ‚Üí "Unsaved" + amber dot; switch tabs and back ‚Üí edits are
   still there; save with the disk button or Ctrl+S ‚Üí indicator clears.
3. **Revert**: edit, then Ctrl+Z back to the original ‚Üí "Unsaved" clears.
4. **Undo across tabs**: edit file A, switch to B, back to A ‚Üí Ctrl+Z still undoes.
5. Ctrl+S does not trigger the browser's save dialog.

### Scope

UI only ‚Äî all changes are under `ui/src/pages/compose`. No backend/proto changes.